### PR TITLE
lower a few dependency requirements

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,11 +1,10 @@
 julia 0.6
-Compat 0.8
 StatsBase 0.11
 DataFrames 0.9
-DataStructures 0.6
+DataStructures 0.5.2
 NLopt 0.3
 ColorTypes 0.2
 Gadfly 0.4
 GLM 0.5
-Combinatorics 0.3
-RCall 0.7.2
+Combinatorics 0.2.1
+RCall 0.6.1


### PR DESCRIPTION
Pkg.test("PhyloNetworks") seems to work fine against DataStructures 0.5.2,
Combinatorics 0.2.1, and RCall 0.6.1, and Compat isn't currently used anywhere in the package