### PR TITLE
Allow function `calibrateFromPairwiseDistances!` to accept `Symbol`s

### DIFF
--- a/src/pairwiseDistanceLS.jl
+++ b/src/pairwiseDistanceLS.jl
@@ -402,3 +402,20 @@ function calibrateFromPairwiseDistances!(net::HybridNetwork,
     verbose && println("got $(round(fmin,5)) at $(round.(xmin,5)) after $(counter[1]) iterations (return code $(ret))")
     return fmin,xmin,ret
 end
+
+# This is a helper function to accept symbols instead of strings
+function calibrateFromPairwiseDistances!(net::HybridNetwork,
+      D::Array{Float64,2}, taxNames::Vector{Symbol};
+      checkPreorder=true::Bool, forceMinorLength0=false::Bool, verbose=false::Bool,
+      ultrametric=true::Bool, NLoptMethod=:LD_MMA::Symbol,
+      ftolRel=fRelBL::Float64, ftolAbs=fAbsBL::Float64,
+      xtolRel=xRelBL::Float64, xtolAbs=xAbsBL::Float64)
+    taxNames = [String(t) for t in taxNames]
+    calibrateFromPairwiseDistances!(net, D, taxNames;
+                                    checkPreorder=checkPreorder,
+                                    forceMinorLength0=forceMinorLength0,
+                                    verbose=verbose, ultrametric=ultrametric,
+                                    NLoptMethod=NLoptMethod, ftolRel=ftolRel,
+                                    ftolAbs=ftolAbs, xtolRel=xtolRel,
+                                    xtolAbs=xtolAbs)
+end

--- a/test/test_calibratePairwise.jl
+++ b/test/test_calibratePairwise.jl
@@ -54,6 +54,14 @@ calibrateFromPairwiseDistances!(net, net2distances, taxa,
 est = pairwiseTaxonDistanceMatrix(net)
 @test est ≈ [0 1.663 2.9 2.8; 1.663 0 2.703 2.603; 2.9 2.703 0 .3;
              2.8 2.603 .3 0] atol=.00002
+
+# Test symbol input
+net = readTopology("((#H1:0.06::0.3,A:0.6):1.3,(B:0.1)#H1:0.7::0.7,(C,D):1.4);");
+taxa = [Symbol(t) for t in taxa]
+calibrateFromPairwiseDistances!(net, net2distances, taxa,
+  verbose=false, forceMinorLength0=false, ultrametric=false)
+estSymb = pairwiseTaxonDistanceMatrix(net)
+@test estSymb ≈ est atol=.00002
 end
 
 @testset "calibrate with distances: 5-cycle example (when unrooted)" begin


### PR DESCRIPTION
This is just a helper function, so that `Symbol`s are also accepted as inputs for taxa names, instead of `String`s. This might be handy if the names come from a `DataFrame`.