### PR TITLE
Fix NLopt build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ addons:
         packages:
             - libnlopt0 # We install it this way to be able to run Travis with `sudo: false`
 
-before_install:
-
-  # Track master of NLopt. This line should be removed when a a new release of NLopt is out.
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then julia -e 'Pkg.clone("https://github.com/JuliaOpt/NLopt.jl"); Pkg.build("NLopt")'; fi
-
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("PhyloNetworks")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ env:
   - DRAW_FIG="false"
 notifications:
   email: false
+## Following 4 lines are taken from here:
+# https://github.com/JuliaOpt/NLopt.jl/blob/master/.travis.yml#L10
+# They're meant to fix the NLopt build on Linux.
+addons:
+    apt: # apt-get for linux
+        packages:
+            - libnlopt0 # We install it this way to be able to run Travis with `sudo: false`
 
 before_install:
 


### PR DESCRIPTION
- Tweak `.travis.ylm` to install `libnlopt0` before hand (for linux build)
- Remove call to master branch for osx (not needed anymore since last release of NLopt).