### PR TITLE
Use Iterators.product instead of IterTools.product

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,7 +6,6 @@ CSV 0.2.1
 DataFrames 0.11 # requires and re-exports Missings
 DataStructures 0.5.2
 GLM 0.10 # requires StatsModels, Distributions
-IterTools 0.1
 NLopt 0.3
 StaticArrays 0.6.0
 StatsBase 0.18

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -11,7 +11,6 @@ module PhyloNetworks
     using NLopt # for branch lengths optimization
     using Combinatorics.combinations
     using StaticArrays
-    using IterTools
     using BioSequences
     using BioSymbols
 

--- a/src/parsimony.jl
+++ b/src/parsimony.jl
@@ -312,7 +312,8 @@ function parsimonySoftwired(net::HybridNetwork, species=Array{String},
         mpscoreSwitchings = Array{Float64}(2^nhyb, nchari) # grabs memory
         # fixit: move that outside to avoid grabbing memory over and over again
         iswitch = 0
-        for switching in IterTools.product([[true, false] for i=1:nhyb]...)
+        perms = nhyb == 0 ? [()] : Iterators.product([[true, false] for i=1:nhyb]...)
+        for switching in perms
             # next: modify the `fromBadDiamondI` of hybrid edges in the blob:
             # switching[h] = pick the major parent of hybrid h if true, pick minor if false
             iswitch += 1
@@ -578,7 +579,9 @@ function parsimonyGF(net::HybridNetwork, species=Array{String},
         nhyb = length(majorEdges[bcnumber])
         #println("site $isite, r.number = $(r.number), nhyb=$(nhyb)")
         firstguess = true
-        for guesses in IterTools.product([1:nchari for i=1:length(guessedparent[bcnumber])]...)
+        gplen = length(guessedparent[bcnumber])
+        perms = gplen == 0 ? [()] : Iterators.product([1:nchari for i=1:gplen]...)
+        for guesses in perms
             #@show guesses
             for pind in 1:nhyb
                 p = guessedparent[bcnumber][pind] # detached parent of hybrid with index pind in blob number pcnumber


### PR DESCRIPTION
`IterTools.product` had weird behaviour with no args before and we plan to deprecate it in favour of `Iterators.product`. However, that method does not have a no-args method.

This is what the old behaviour was:

```julia
julia> nhyb = 2; collect(IterTools.product([[true, false] for i=1:nhyb]...))
4-element Array{Tuple{Bool,Bool},1}:
 (true, true)
 (false, true)
 (true, false)
 (false, false)

julia> nhyb = 1; collect(IterTools.product([[true, false] for i=1:nhyb]...))
2-element Array{Tuple{Bool},1}:
 (true,)
 (false,)

julia> nhyb = 0; collect(IterTools.product([[true, false] for i=1:nhyb]...))
1-element Array{Tuple{},1}:
 ()
```

It's unclear whether the nhyb=0 case is an appropriate generalization in your case, but this PR implements a special case for that behaviour, and tests pass.