### PR TITLE
Add vcv function

### DIFF
--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -121,6 +121,7 @@ descendenceMatrix
 regressorShift
 regressorHybrid
 sharedPathMatrix
+vcv
 ```
 
 ## discrete trait evolution

--- a/docs/src/man/trait_tree.md
+++ b/docs/src/man/trait_tree.md
@@ -12,7 +12,7 @@ More details can be found on the developments below in Bastide et al. 2018[^fnBa
 
 [^fnBastide2018]: Bastide, Solís-Lemus, Kriebel, Sparks, Ané (2018):
                   Phylogenetic Comparative Methods for Phylogenetic Networks with Reticulations.
-                  Systematic Biology. doi:10.1093/sysbio/syy033
+                  Systematic Biology 67(5):800–820. doi:10.1093/sysbio/syy033
 
 We assume a fixed network, correctly rooted, with branch lengths
 proportional to calendar time. Here, we consider the true network that was
@@ -42,12 +42,12 @@ nothing # hide
 Assuming that the network is known and that the continuous traits evolve like a
 Brownian Motion (BM) in time, it is possible to compute the expected variance
 covariance matrix between tip measurements. This can be done using function
-[`vcv`](@ref), which syntax is inspired from the well known corresponding
+[`vcv`](@ref), whose syntax is inspired from the well known corresponding
 [`ape`](https://CRAN.R-project.org/package=ape) function.
 ```@example tree_trait
 C = vcv(truenet)
 ```
-The matrix is returned as a `DataFrame`, with columns named as the
+The matrix is returned as a `DataFrame`, with columns named by the
 tips of the network to allow for easy identification.
 
 The computation of this matrix is based on the more general function

--- a/docs/src/man/trait_tree.md
+++ b/docs/src/man/trait_tree.md
@@ -37,6 +37,24 @@ nothing # hide
 ```
 ![truenet](../assets/figures/truenet.svg)
 
+## Model and Variance Matrix
+
+Assuming that the network is known and that the continuous traits evolve like a
+Brownian Motion (BM) in time, it is possible to compute the expected variance
+covariance matrix between tip measurements. This can be done using function
+[`vcv`](@ref), which syntax is inspired from the well known corresponding
+[`ape`](https://CRAN.R-project.org/package=ape) function.
+```@example tree_trait
+C = vcv(truenet)
+```
+The matrix is returned as a `DataFrame`, with columns named as the
+tips of the network to allow for easy identification.
+
+The computation of this matrix is based on the more general function
+[`sharedPathMatrix`](@ref). It is at the core of all the Phylogenetic
+Comparative Methods described below.
+
+
 ## Trait simulation
 
 We start by generating continuous traits to study. We simulate three

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -115,6 +115,7 @@ module PhyloNetworks
         expectationsPlot,
         predint,
         predintPlot,
+        vcv,
         ## Discrete Trait PCM
         parsimonySoftwired,
         parsimonyGF,

--- a/src/parsimony.jl
+++ b/src/parsimony.jl
@@ -1006,7 +1006,7 @@ end
 ## find the maximum parsimony network;
 ## transform the starting topology first
 ## does not allow multiple alleles
-@doc (@doc maxPArsimonyNetRun1!) maxParsimonyNetRun1
+@doc (@doc maxParsimonyNetRun1!) maxParsimonyNetRun1
 function maxParsimonyNetRun1(currT0::HybridNetwork, df::DataFrame, Nfail::Integer, tolAbs::Float64,
                                       hmax::Integer,seed::Integer,logfile::IO, writelog::Bool, probST::Float64,
                                       outgroup::Union{AbstractString,Integer}, criterion=:softwired::Symbol)
@@ -1071,7 +1071,7 @@ Optional arguments include
    On computing the Maximum Parsimony score of a phylogenetic network.
    SIAM J. Discrete Math., 29(1):559-585.
 
-For a roadmap of the functions inside maxParsimonyNet, see [`maxPArsimonyNetRun1!`](@ref).
+For a roadmap of the functions inside maxParsimonyNet, see [`maxParsimonyNetRun1!`](@ref).
 """
 function maxParsimonyNet(currT::HybridNetwork, df::DataFrame;
     tolAbs=fAbs::Float64, Nfail=numFails::Integer,

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -285,10 +285,11 @@ This function computes the variance covariance matrix between the tips of the
 network, assuming a Brownian model of trait evolution (with unit variance).
 If optional argument `corr` is set to `true`, then the correlation matrix is returned instead.
 
-The function returns a `DataFrame` objects, with columns named as the tips of the network.
+The function returns a `DataFrame` object, with columns named by the tips of the network.
 
-It assumes that the network is in the pre-order. If checkPreorder is
-true (default), then it runs function `preoder` on the network beforehand.
+The calculation of the covariance matrix requires a pre-ordering of nodes to be fast.
+If `checkPreorder` is true (default), then `preorder` is run on the network beforehand.
+Otherwise, the network is assumed to be already in pre-order.
 
 This function internally calls [`sharedPathMatrix`](@ref), that computes the variance
 matrix between all the nodes of the network.
@@ -323,6 +324,20 @@ t3 0.14 0.14 1.10 0.0 0.00
 t5 0.00 0.00 0.00 1.6 0.90
 t1 0.00 0.00 0.00 0.9 1.08
 
+```
+
+The covariance can also be calculated on a network
+(for the model, see for Bastide et al. 2018)
+```jldoctest
+julia> net = readTopology("((t1:1.0,#H1:0.1::0.30):0.5,((t2:0.9)#H1:0.2::0.70,t3:1.1):0.4);");
+
+julia> C = vcv(net)
+3×3 DataFrames.DataFrame
+│ Row │ t1   │ t2    │ t3   │
+├─────┼──────┼───────┼──────┤
+│ 1   │ 1.5  │ 0.15  │ 0.0  │
+│ 2   │ 0.15 │ 1.248 │ 0.28 │
+│ 3   │ 0.0  │ 0.28  │ 1.5  │
 ```
 """
 function vcv(net::HybridNetwork;

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -9,7 +9,7 @@
 
 # Matrix with rows and/or columns in topological order of the net.
 """
-`MatrixTopologicalOrder`
+    MatrixTopologicalOrder
 
 Matrix associated to an [`HybridNetwork`](@ref) sorted in topological order.
 
@@ -221,7 +221,7 @@ end
 
 # If some tips are missing, treat them as "internal nodes"
 """
-`getindex(obj, d,[ indTips, msng])`
+    getindex(obj, d,[ indTips, msng])
 
 Getting submatrices of an object of type [`MatrixTopologicalOrder`](@ref).
 
@@ -402,7 +402,7 @@ end
 ###############################################################################
 ###############################################################################
 """
-`descendenceMatrix(net::HybridNetwork; checkPreorder=true::Bool)`
+    descendenceMatrix(net::HybridNetwork; checkPreorder=true::Bool)
 
 This function computes the inciednce matrix between all the nodes of a
 network. It assumes that the network is in the pre-order. If checkPreorder is
@@ -448,7 +448,7 @@ end
 ###############################################################################
 ###############################################################################
 """
-`regressorShift(node::Vector{Node}, net::HybridNetwork; checkPreorder=true::Bool)`
+    regressorShift(node::Vector{Node}, net::HybridNetwork; checkPreorder=true::Bool)
 
 `regressorShift(edge::Vector{Edge}, net::HybridNetwork; checkPreorder=true::Bool)`
 
@@ -582,7 +582,7 @@ regressorShift(edge::Edge, net::HybridNetwork; checkPreorder=true::Bool) = regre
 regressorShift(node::Node, net::HybridNetwork; checkPreorder=true::Bool) = regressorShift([node], net; checkPreorder=checkPreorder)
 
 """
-`regressorHybrid(net::HybridNetwork; checkPreorder=true::Bool)`
+    regressorHybrid(net::HybridNetwork; checkPreorder=true::Bool)
 
 Compute the regressor vectors associated with shifts on edges that imediatly below
 all hybrid nodes of `net`. It uses function [`descendenceMatrix`](@ref) through
@@ -688,7 +688,7 @@ abstract type ParamsProcess end
 
 # Type for shifts
 """
-`ShiftNet`
+    ShiftNet
 
 Shifts associated to a [`HybridNetwork`](@ref) sorted in topological order.
 Its `shift` field is a vector of shift values, one for each node,
@@ -746,7 +746,7 @@ ShiftNet(edge::Edge, value::Real, net::HybridNetwork; checkPreorder=true::Bool) 
 ShiftNet(node::Node, value::Real, net::HybridNetwork; checkPreorder=true::Bool) = ShiftNet([node], [value], net; checkPreorder=checkPreorder)
 
 """
-`shiftHybrid(value::Vector{T} where T<:Real, net::HybridNetwork; checkPreorder=true::Bool)`
+    shiftHybrid(value::Vector{T} where T<:Real, net::HybridNetwork; checkPreorder=true::Bool)
 
 Construct an object [`ShiftNet`](@ref) with shifts on all the edges below
 hybrid nodes, with values provided. The vector of values must have the
@@ -764,7 +764,7 @@ end
 shiftHybrid(value::Real, net::HybridNetwork; checkPreorder=true::Bool) = shiftHybrid([value], net; checkPreorder=checkPreorder)
 
 """
-`getShiftEdgeNumber(shift::ShiftNet)`
+    getShiftEdgeNumber(shift::ShiftNet)
 
 Get the edge numbers where the shifts are located, for an object [`ShiftNet`](@ef).
 """
@@ -780,7 +780,7 @@ function getMajorParentEdgeNumber(n::Node)
     end
 end
 """
-`getShiftValue(shift::ShiftNet)`
+    getShiftValue(shift::ShiftNet)
 
 Get the values of the shifts, for an object [`ShiftNet`](@ef).
 """
@@ -825,7 +825,7 @@ end
 # end
 
 """
-`ParamsBM <: ParamsProcess`
+    ParamsBM <: ParamsProcess
 
 Type for a BM process on a network. Fields are `mu` (expectation),
 `sigma2` (variance), `randomRoot` (whether the root is random, default to `false`),
@@ -884,7 +884,7 @@ end
 ###############################################################################
 
 """
-`TraitSimulation`
+    TraitSimulation
 
 Result of a trait simulation on an [`HybridNetwork`](@ref) with function [`simulate`](@ref).
 
@@ -912,7 +912,7 @@ end
 
 
 """
-`simulate(net::HybridNetwork, params::ParamsProcess, checkPreorder=true::Bool)`
+    simulate(net::HybridNetwork, params::ParamsProcess, checkPreorder=true::Bool)
 
 Simualte some traits on `net` using the parameters `params`. For now, only
 parameters of type [`ParamsBM`](@ref) (Brownian Motion) are accepted.
@@ -1063,7 +1063,7 @@ end
 
 # Extract the vector of simulated values at the tips
 """
-`getindex(obj, d)`
+    getindex(obj, d)
 
 Getting submatrices of an object of type [`TraitSimulation`](@ref).
 
@@ -1093,7 +1093,7 @@ end
 
 # New type for phyloNetwork regression
 """
-`PhyloNetworkLinearModel<:LinPredModel`
+    PhyloNetworkLinearModel<:LinPredModel
 
 Regression object for a phylogenetic regression. Result of fitting function [`phyloNetworklm`](@ref).
 Dominated by the `LinPredModel` class, from package `GLM`.
@@ -1752,7 +1752,8 @@ end
 ## New quantities
 # ML estimate for variance of the BM
 """
-`sigma2_estim(m::PhyloNetworkLinearModel)`
+    sigma2_estim(m::PhyloNetworkLinearModel)
+
 Estimated variance for a fitted object.
 """
 sigma2_estim(m::PhyloNetworkLinearModel) = deviance(m.lm) / nobs(m)
@@ -1761,7 +1762,8 @@ sigma2_estim(m::StatsModels.DataFrameRegressionModel{PhyloNetworkLinearModel,T} 
   sigma2_estim(m.model)
 # ML estimate for ancestral state of the BM
 """
-`mu_estim(m::PhyloNetworkLinearModel)`
+    mu_estim(m::PhyloNetworkLinearModel)
+
 Estimated root value for a fitted object.
 """
 function mu_estim(m::PhyloNetworkLinearModel)
@@ -1784,7 +1786,8 @@ function mu_estim(m::StatsModels.DataFrameRegressionModel{PhyloNetworkLinearMode
 end
 # Lambda estim
 """
-`lambda_estim(m::PhyloNetworkLinearModel)`
+    lambda_estim(m::PhyloNetworkLinearModel)
+
 Estimated lambda parameter for a fitted object.
 """
 lambda_estim(m::PhyloNetworkLinearModel) = m.lambda
@@ -1852,7 +1855,7 @@ end
 ###############################################################################
 
 """
-`anova(objs::PhyloNetworkLinearModel...)`
+    anova(objs::PhyloNetworkLinearModel...)
 
 Takes several nested fits of the same data, and computes the F statistic for each
 pair of models.
@@ -1900,7 +1903,7 @@ end
 ###############################################################################
 # Class for reconstructed states on a network
 """
-`ReconstructedStates`
+    ReconstructedStates
 
 Type containing the inferred information about the law of the ancestral states
 given the observed tips values. The missing tips are considered as ancestral states.
@@ -1928,7 +1931,8 @@ struct ReconstructedStates
 end
 
 """
-`expectations(obj::ReconstructedStates)`
+    expectations(obj::ReconstructedStates)
+
 Estimated reconstructed states at the nodes and tips.
 """
 function expectations(obj::ReconstructedStates)
@@ -1936,7 +1940,8 @@ function expectations(obj::ReconstructedStates)
 end
 
 """
-`expectationsPlot(obj::ReconstructedStates)`
+    expectationsPlot(obj::ReconstructedStates)
+
 Compute and format the expected reconstructed states for the plotting function.
 The resulting dataframe can be readily used as a `nodeLabel` argument to
 `plot` from package [`PhyloPlots`](https://github.com/cecileane/PhyloPlots.jl).
@@ -1966,7 +1971,8 @@ end
 StatsBase.stderror(obj::ReconstructedStates) = sqrt.(diag(obj.variances_nodes))
 
 """
-`predint(obj::ReconstructedStates; level=0.95::Real)`
+    predint(obj::ReconstructedStates; level=0.95::Real)
+
 Prediction intervals with level `level` for internal nodes and missing tips.
 """
 function predint(obj::ReconstructedStates; level=0.95::Real)
@@ -1988,7 +1994,8 @@ function Base.show(io::IO, obj::ReconstructedStates)
 end
 
 """
-`predintPlot(obj::ReconstructedStates; level=0.95::Real, withExp=false::Bool)`
+    predintPlot(obj::ReconstructedStates; level=0.95::Real, withExp=false::Bool)
+
 Compute and format the prediction intervals for the plotting function.
 The resulting dataframe can be readily used as a `nodeLabel` argument to
 `plot` from package [`PhyloPlots`](https://github.com/cecileane/PhyloPlots.jl).
@@ -2031,7 +2038,7 @@ end
 # end
 
 """
-`ancestralStateReconstruction(net::HybridNetwork, Y::Vector, params::ParamsBM)`
+    ancestralStateReconstruction(net::HybridNetwork, Y::Vector, params::ParamsBM)
 
 Compute the conditional expectations and variances of the ancestral (un-observed)
 traits values at the internal nodes of the phylogenetic network (`net`),
@@ -2154,7 +2161,7 @@ function ancestralStateReconstruction(obj::PhyloNetworkLinearModel, X_n::Matrix)
 end
 
 """
-`ancestralStateReconstruction(obj::PhyloNetworkLinearModel[, X_n::Matrix])`
+    ancestralStateReconstruction(obj::PhyloNetworkLinearModel[, X_n::Matrix])
 
 Function to find the ancestral traits reconstruction on a network, given an
 object fitted by function [`phyloNetworklm`](@ref). By default, the function assumes
@@ -2449,7 +2456,7 @@ function ancestralStateReconstruction(obj::StatsModels.DataFrameRegressionModel{
 end
 
 """
-`ancestralStateReconstruction(fr::AbstractDataFrame, net::HybridNetwork; kwargs...)`
+    ancestralStateReconstruction(fr::AbstractDataFrame, net::HybridNetwork; kwargs...)
 
 Function to find the ancestral traits reconstruction on a network, given some data at the tips.
 Uses function [`phyloNetworklm`](@ref) to perform a phylogenetic regression of the data against an

--- a/test/test_traits.jl
+++ b/test/test_traits.jl
@@ -38,6 +38,31 @@ V2 = V2[ind, ind]
 @test V1[:All] ≈ V2
 
 ########################
+## vcv function
+########################
+
+## Simple test
+C = convert(Array, vcv(net))
+@test C ≈ V1[:Tips]
+vv = diag(C)
+for i in 1:4
+    for j in 1:4
+        C[i, j] = C[i, j] / sqrt(vv[i] * vv[j])
+    end
+end
+@test convert(Array, vcv(net; corr = true)) ≈ C
+
+## Test names with tree
+tree_str = "(((t2:0.1491947961,t4:0.3305515735):0.5953111246,t3:0.9685578963):0.1415281736,(t5:0.7093406462,t1:0.1888024569):0.9098094522);"
+tree = readTopology(tree_str)
+C = vcv(tree)
+# C_R = R"ape::vcv(ape::read.tree(text = $tree_str))"
+# names_R = rcopy(R"colnames($C_R)")
+names_R = ["t2", "t4", "t3", "t5", "t1"]
+
+@test names(C) == map(Symbol, names_R)
+
+########################
 ## Descendence Matrix Test
 ########################
 tree_str= "(A:0.5,((B:1,#H1:1::0.4):1,(C:1,(D:1)#H1:1::0.6):1):0.5);"


### PR DESCRIPTION
Add a wrapper `vcv` function that reproduces the `R` `ape::vcv` one, in line with discussions with @crsl4. 

To this end, the function returns a `DataFrame` instead of a matrix: this makes the relationships between the tips more obvious. I could not name the rows to reproduce exactly `ape::vcv` (I'm not sure if it's possible ?), but this should be already more readable than the previous version.

I added a paragraph in the documentation, before the trait simulation, since this is just dependent on the model, and not on any data.

What do you think ? Feel free to edit / comment before optional merge.