### PR TITLE
Manually specify versions of mkdocs and mkdocs-material

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,8 +2,11 @@ using Documenter, PhyloNetworks
 
 makedocs()
 
+# Versions of `mkdocs` and `mkdocs-material` specified manually to avoid conflicts. 
+# See here: https://discourse.julialang.org/t/mkdocs-material-in-documenter/13764/3
+# To be kept in mind: those versions might evolve in the future.
 deploydocs(
-    deps   = Deps.pip("pygments", "mkdocs", "mkdocs-material", "python-markdown-math"),
+    deps   = Deps.pip("pygments", "mkdocs==0.17.5", "mkdocs-material==2.9.4", "python-markdown-math"),
     repo = "github.com/crsl4/PhyloNetworks.jl.git",
     julia  = "0.6",
     osname = "linux"


### PR DESCRIPTION
For all the documentation builds after August 4th, we ran into the issue described [here]( https://discourse.julialang.org/t/mkdocs-material-in-documenter/13764).

I applied the fix proposed in the link above to a test travis documentation branch, and it seemed to work (see result [here](http://pbastide.github.io/PhyloNetworks.jl/latest/man/parsimony/#Parsimony-on-networks-1)).

We might need to keep that fix in mind, in case the versions we want to use change in the future. I added some comments in the code, but maybe there is a better place to add this warning ?