### PR TITLE
Simulating trait data under multivariate Brownian diffusion

### DIFF
--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -108,6 +108,7 @@ module PhyloNetworks
         simulate,
         TraitSimulation,
         ParamsBM,
+        ParamsMultiBM,
         ShiftNet,
         shiftHybrid,
         getShiftEdgeNumber,

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -859,7 +859,7 @@ end
 
 Type for a BM process on a network. Fields are `mu` (expectation),
 `sigma2` (variance), `randomRoot` (whether the root is random, default to `false`),
-and `varRoot` (if the root is random, the variance of the root, defalut to `NaN`).
+and `varRoot` (if the root is random, the variance of the root, default to `NaN`).
 
 """
 mutable struct ParamsBM <: ParamsProcess

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -937,7 +937,6 @@ end
 
 function anyShift(params::ParamsMultiBM)
     # TODO
-    @warn "Shifts not currently implemented. Returning false."
     return false
 end
 
@@ -1168,7 +1167,7 @@ function updateTreeSimulateMBD!(M::Matrix{Float64},
 
     means[:, i] .= means[:, parentIndex]# expectation
     vals[:, i] .= vals[:, parentIndex] + sqrt(edge.length) * params.L * randn(p) # random value #TODO: make memory efficient
-    # TODO: add shifts
+    # TODO: shifts
 end
 
 
@@ -1202,7 +1201,7 @@ function updateHybridSimulateMBD!(M::Matrix{Float64},
     means[:, i] .= edge1.gamma * means[:, parentIndex1] + edge2.gamma * means[:, parentIndex2] # expectation
     vals[:, i] .=  edge1.gamma * (vals[:, parentIndex1] + sqrt(edge1.length) * params.L * randn(p)) +
                     edge2.gamma * (vals[:, parentIndex2] + sqrt(edge2.length) * params.L * randn(p)) # random value
-    # TODO: shifts?
+    # TODO: shifts
     # TODO: memory efficincy
 end
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -916,7 +916,7 @@ Type for a multivariate Brownian diffusion (MBD) process on a network. Fields ar
 and `L` (the lower triangular of the cholesky decomposition of `sigma`, computed automatically)
 
 """
-struct ParamsMultiBM <: ParamsProcess
+mutable struct ParamsMultiBM <: ParamsProcess
     mu::AbstractArray{Float64, 1}
     sigma::AbstractArray{Float64, 2}
     randomRoot::Bool
@@ -928,6 +928,8 @@ end
 ParamsMultiBM(mu::AbstractArray{Float64, 1},
                 sigma::AbstractArray{Float64, 2}) =
         ParamsMultiBM(mu, sigma, false, Diagonal([NaN]), missing, cholesky(sigma).L)
+
+# TODO: add more constructors
 
 
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -2608,6 +2608,30 @@ function updateHybridSimulateMBD!(M::Matrix{Float64},
     # TODO: memory efficincy
 end
 
+function Base.show(io::IO, obj::ParamsMultiBM)
+    disp =  "$(typeof(obj)):\n"
+    pt = paramstable(obj)
+    if obj.randomRoot
+        disp = disp * "Parameters of a BM with random root:\n" * pt
+    else
+        disp = disp * "Parameters of a BM with fixed root:\n" * pt
+    end
+    println(io, disp)
+end
+
+function paramstable(obj::ParamsMultiBM)
+    disp = "mu: $(obj.mu)\nSigma: $(obj.sigma)"
+    if obj.randomRoot
+        disp = disp * "\nvarRoot: $(obj.varRoot)"
+    end
+    if anyShift(obj)
+        disp = disp * "\n\nThere are $(length(getShiftValue(obj.shift))) shifts on the network:\n"
+        disp = disp * "$(shiftTable(obj.shift))"
+    end
+    return(disp)
+end
+
+
 
 
 #################################################

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -905,8 +905,17 @@ function paramstable(obj::ParamsBM)
     return(disp)
 end
 
-## ParamsMultiBM
 
+"""
+    ParamsMultiBM <: ParamsProcess
+
+Type for a multivariate Brownian diffusion (MBD) process on a network. Fields are `mu` (expectation),
+`sigma` (covariance matrix), `randomRoot` (whether the root is random, default to `false`),
+`varRoot` (if the root is random, the covariance matrix of the root, default to `[NaN]`),
+`shift` (a ShiftNet type, default to `missing`),
+and `L` (the lower triangular of the cholesky decomposition of `sigma`, computed automatically)
+
+"""
 mutable struct ParamsMultiBM <: ParamsProcess
     mu::AbstractArray{Float64, 1}
     sigma::AbstractArray{Float64, 2}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,7 +86,7 @@ tests = [
     "test_bootstrap.jl",
     "test_perfectData.jl", # "test_readme.jl"
     "test_moves_semidirected.jl",
-    "test_lm.jl", "test_lm_tree.jl", "test_traits.jl", "test_simulate.jl",
+    "test_lm.jl", "test_lm_tree.jl", "test_traits.jl", "test_simulate.jl", "test_simulate_mbd.jl",
     "test_parsimony.jl",
     "test_calibratePairwise.jl", "test_relaxed_reading.jl",
     "test_isMajor.jl", "test_interop.jl",

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -2,15 +2,15 @@
 
 ## Get a network and make it ultrametric
 net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");
-P = 3
+trait_dim = 3
 
 
 @testset "Simulate data and check means and dimensions" begin
 
 ## Simulate a MBD
 Random.seed!(17920921); # fix the seed
-μ = randn(P)
-Σ = randn(P, P)
+μ = randn(trait_dim)
+Σ = randn(trait_dim, trait_dim)
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
 @test_logs show(devnull, pars)
@@ -23,8 +23,8 @@ traitsTips = sim[:Tips];
 traitsNodes = sim[:InternalNodes];
 
 # Check dimensions
-@test size(traitsTips) == (P, net.numTaxa)
-@test size(traitsNodes) == (P, net.numNodes - net.numTaxa)
+@test size(traitsTips) == (trait_dim, net.numTaxa)
+@test size(traitsNodes) == (trait_dim, net.numNodes - net.numTaxa)
 
 expectations = sim[:All, :Exp]
 
@@ -41,15 +41,15 @@ end
 
 ## Generate some values
 Random.seed!(18480224); # fix the seed
-μ = randn(P)
-Σ = randn(P, P)
+μ = randn(trait_dim)
+Σ = randn(trait_dim, trait_dim)
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
 
 N = 50000
 S = length(tipLabels(net));
-μ_sim = zeros(P, S)
-Σ_sim = zeros(P * S, P * S)
+μ_sim = zeros(trait_dim, S)
+Σ_sim = zeros(trait_dim * S, trait_dim * S)
 for i = 1:N
     tips = simulate(net, pars)[:Tips]
     μ_sim .+= tips

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -5,7 +5,7 @@ net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H
 P = 3
 
 
-@testset "Simulate function against fixed values" begin
+@testset "Simulate data and check means and dimensions" begin
 
 ## Simulate a MBD
 Random.seed!(17920921); # fix the seed
@@ -27,7 +27,6 @@ traitsNodes = sim[:InternalNodes];
 @test size(traitsNodes) == (P, net.numNodes - net.numTaxa)
 
 expectations = sim[:All, :Exp]
-@show size(expectations)
 
 # Check means (no shifts)
 max_diff = maximum(expectations - μ * ones(net.numNodes)')

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -1,0 +1,80 @@
+# Tests to simulate multivariate traits
+
+## Get a network and make it ultrametric
+net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");
+P = 3
+
+
+@testset "Simulate function against fixed values" begin
+
+## Simulate a MBD
+Random.seed!(17920921); # fix the seed
+μ = randn(P)
+Σ = randn(P, P)
+Σ = Σ * Σ' # needs to be positive definite
+pars = ParamsMultiBM(μ, Σ); # params of a MBD
+@test_logs show(devnull, pars)
+
+sim = simulate(net, pars); # simulate according to a BM
+@test_logs show(devnull, sim)
+
+# Extract simulated values
+traitsTips = sim[:Tips];
+traitsNodes = sim[:InternalNodes];
+
+# Check dimensions
+@test size(traitsTips) == (P, net.numTaxa)
+@test size(traitsNodes) == (P, net.numNodes - net.numTaxa)
+
+expectations = sim[:All, :Exp]
+@show size(expectations)
+
+# Check means (no shifts)
+max_diff = maximum(expectations - μ * ones(net.numNodes)')
+@test max_diff ≈ 0.0 atol=1e-10
+
+end
+
+###############################################################################
+## Test of distibution
+###############################################################################
+@testset "Simulate test distribution" begin
+
+## Generate some values
+Random.seed!(18480224); # fix the seed
+μ = randn(P)
+Σ = randn(P, P)
+Σ = Σ * Σ' # needs to be positive definite
+pars = ParamsMultiBM(μ, Σ); # params of a MBD
+
+N = 50000
+S = length(tipLabels(net));
+μ_sim = zeros(P, S)
+Σ_sim = zeros(P * S, P * S)
+for i = 1:N
+    tips = simulate(net, pars)[:Tips]
+    μ_sim .+= tips
+    v_sim = vec(tips)
+    Σ_sim += v_sim * v_sim'
+end
+
+μ_sim ./= N
+Σ_sim ./= N
+Σ_sim = Σ_sim - vec(μ_sim) * vec(μ_sim)'
+
+## Check means
+
+μ_true = μ * ones(S)'
+
+μ_max = maximum(abs.(μ_true - μ_sim))
+@test μ_max < 1e-1
+
+## Check covariance
+
+Ψ = Matrix(vcv(net))
+Σ_true = kron(Ψ, Σ)
+Σ_max = maximum(abs.(Σ_true - Σ_sim))
+@test Σ_max < 2e-1
+
+
+end


### PR DESCRIPTION
Adding the `ParamsMultiBM` type for simulating multivariate Brownian diffusion on a tree/network. Shifts are not currently implemented and some functions could be made more memory efficient, but otherwise it should work for any situation where `ParamsBM` does.