### PR TITLE
bug fixes: root and gamma NaN

### DIFF
--- a/docs/src/man/multiplealleles.md
+++ b/docs/src/man/multiplealleles.md
@@ -29,7 +29,7 @@ even if the gene trees may have multiple alleles from the same species.
 For 4 distinct species `A,B,C,D`, all alleles from each species (`A` etc.)
 will be used to calculate the quartet CF. If a given gene tree has
 `n_a` alleles from `a`, `n_b` alleles from `b` etc., then
-each set of 4 alleles is given a weight of `1/(n_a n_b b_c n_c)`
+each set of 4 alleles is given a weight of `1/(n_a n_b n_c n_d)`
 to calculated of the CF for `A,B,C,D` (such that the total weight from
 this particular gene trees is 1).
 It is save to save this data frame, then use it for `snaq!` like this:

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -1526,7 +1526,7 @@ function shrink2cycleat!(net::HybridNetwork, minor::Edge, major::Edge,
     if g == -1.0 g=.5; end
     major.length = addBL(multiplygammas(    g, minor.length),
                          multiplygammas(1.0-g, major.length))
-    deletehybridedge!(net, minor, false,unroot,false,false) # nofuse,unroot,multgammas,simplify
+    deletehybridedge!(net, minor, false,unroot,false,false,false) # nofuse,unroot,multgammas,simplify
     return nothing
 end
 

--- a/src/moves_semidirected.jl
+++ b/src/moves_semidirected.jl
@@ -890,7 +890,7 @@ function moveroot!(net::HybridNetwork, constraints=TopologyConstraint[]::Vector{
             directEdges!(net) # revert edges' directions to match original rooting
             continue # to next potential new root
         end
-        # If we get here newrooti passed all the checks
+        # if we get here: newrooti passed all the checks
         return true
     end
     # if we get here: none of the root positions worked

--- a/src/moves_semidirected.jl
+++ b/src/moves_semidirected.jl
@@ -890,9 +890,7 @@ function moveroot!(net::HybridNetwork, constraints=TopologyConstraint[]::Vector{
             directEdges!(net) # revert edges' directions to match original rooting
             continue # to next potential new root
         end
-        # Confirm root isnt part of W structure (if so, one displayed tree won't contain root)
-        sum(n.hybrid for n in getChildren(newrootnode)) < 2 || continue
-        # If we get here: newrooti passed all the checks
+        # If we get here newrooti passed all the checks
         return true
     end
     # if we get here: none of the root positions worked

--- a/src/moves_semidirected.jl
+++ b/src/moves_semidirected.jl
@@ -890,7 +890,9 @@ function moveroot!(net::HybridNetwork, constraints=TopologyConstraint[]::Vector{
             directEdges!(net) # revert edges' directions to match original rooting
             continue # to next potential new root
         end
-        # if we get here: newrooti passed all the checks
+        # Confirm root isnt part of W structure (if so, one displayed tree won't contain root)
+        sum(n.hybrid for n in getChildren(newrootnode)) < 2 || continue
+        # If we get here: newrooti passed all the checks
         return true
     end
     # if we get here: none of the root positions worked

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -837,6 +837,7 @@ function deletehybridedgeLiNC!(obj::SSM, currLik::Float64,
         no3cycle::Bool,
         constraints::Vector{TopologyConstraint},
         γcache::CacheGammaLiNC, lcache::CacheLengthLiNC)
+
     nh = length(obj.net.hybrid)
     hybridnode = obj.net.hybrid[Random.rand(1:nh)]
     minorhybridedge = getMinorParentEdge(hybridnode)
@@ -1001,14 +1002,17 @@ If the displayed tree does not contain the root node, find the child of the
 network's root that is a tree node, then make this node the root of the displayed tree.
 """
 function updateSSM_root!(obj::SSM)
-    rnum = obj.net.node[obj.net.root].number
+    netroot = obj.net.node[obj.net.root]
+    rnum = netroot.number
     for tre in obj.displayedtree
         r = findfirst(n -> n.number == rnum, tre.node)
         if isnothing(r)
-            netrootnum = findfirst(n -> !n.hybrid, getChildren(obj.net.node[obj.net.root]))
-            tre.root = findfirst(n -> n.number == netrootnum, tre.node)
+            i = findfirst(e -> !getChild(e).hybrid, netroot.edge)
+            isnothing(i) && error("the root's children are all hybrids: there must be a 2-cycle...")
+            treechild = getChild(netroot.edge[i])
+            tre.root = findfirst(n -> n.number == treechild.number, tre.node)
         else
-            tre.root = findfirst(n -> n.number == rnum, tre.node)
+            tre.root = r
         end
         directEdges!(tre)
         preorder!(tre)

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -624,7 +624,7 @@ function optimizestructure!(obj::SSM, maxmoves::Integer, maxhybrid::Integer,
                         no3cycle, constraints, γcache, lcache)
         else # change root (doesn't affect likelihood)
             result = moveroot!(obj.net, constraints)
-            updateSSM_root!(obj) # edge direction used by updatecache_edge
+            isnothing(result) || updateSSM_root!(obj) # edge direction used by updatecache_edge
         end
         # optimize γ's
         ghosthybrid = optimizeallgammas_LiNC!(obj, ftolAbs, γcache, 1)
@@ -996,6 +996,16 @@ end
 function updateSSM_root!(obj::SSM)
     rnum = obj.net.node[obj.net.root].number
     for tre in obj.displayedtree
+        r = findfirst(n -> n.number == rnum, tre.node)
+        if isnothing(r)
+            @info "network, with root index $(obj.net.root), number $rnum:"
+            printEdges(obj.net)
+            printNodes(obj.net)
+            @info "displayed tree, with root index $(tre.root), number $(tre.node[tre.root].number):"
+            printEdges(tre)
+            printNodes(tre)
+            error("network root node number not found in displayed tree")
+        end
         tre.root = findfirst(n -> n.number == rnum, tre.node)
         directEdges!(tre)
         preorder!(tre)

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -1313,6 +1313,12 @@ Warnings:
 """
 function optimizelength_LiNC!(obj::SSM, focusedge::Edge,
                           lcache::CacheLengthLiNC, qmat, ltw)
+    # confirm branch lengths inside bounds #TODO needs to be tested
+    if focusedge.length < BLmin
+        focusedge.length = BLmin
+    elseif focusedge.length > BLmax
+        focusedge.length = BLmax
+    end
     cfg = updatecache_edge!(lcache, obj, focusedge)
     flike  = lcache.flike
     dblike = lcache.dblike

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -646,16 +646,6 @@ function optimizestructure!(obj::SSM, maxmoves::Integer, maxhybrid::Integer,
                 nreject += 1
             end
         end
-        if any(isnan(e.gamma) for e in obj.net.edge)
-            @info "Some gamma values are NaN"
-            printEdges(obj.net)
-            printNodes(obj.net)
-        end
-        if any(isnan(e.length) for e in obj.net.edge)
-            @info "Some length values are NaN"
-            printEdges(obj.net)
-            printNodes(obj.net)
-        end
         @debug "$(movechoice) move was " *
           (isnothing(result) ? "not permissible" : (result ? "accepted" : "rejected and undone")) *
           ", $nmoves total moves, $nreject rejected,\nloglik = $(obj.loglik)"
@@ -871,12 +861,6 @@ function deletehybridedgeLiNC!(obj::SSM, currLik::Float64,
     # set γ to 0 to delete the hybrid edge: makes it easy to undo.
     # update minor edge, and prior log tree weights in obj
     γ0 = minorhybridedge.gamma
-    if isnan(γ0)
-        printEdges(obj.net)
-        printNodes(obj.net)
-        @show obj.net.hybrid
-        error("wants to keep hybrid, but the value of γ0 is now NaN: $γ0")
-    end
     setGamma!(minorhybridedge, 0.0)
     l1mγ = log(1.0-γ0)
     nt, hase = updatecache_hase!(γcache, obj, minorhybridedge.number,
@@ -906,9 +890,6 @@ function deletehybridedgeLiNC!(obj::SSM, currLik::Float64,
         return true
     else # keep hybrid
         majhyb.length = len0
-        if isnan(γ0)
-            error("keep hybrid, but the value of γ0 is now NaN: $γ0")
-        end
         setGamma!(minorhybridedge, γ0)
         # note: transition probability for majhyb not updated here, but could be
         #       if we wanted to avoid full update before each branch length optim

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -115,9 +115,8 @@ Optional arguments (default value in parenthesis):
 
 Main optional keyword arguments (default value in parenthesis):
 - `speciesfile` (""): path to a csv file with samples in rows and two columns:
-  species (column 1), individuals (column 2)
-  Used to group individuals by species (in a species constraint). Required if the
-  data contain more than one individual in at least one species.
+  species (column 1), individual (column 2)
+  Include this file to group individuals by species.
 - `cladefile` (""): path to a csv file containing two columns:
   clades and individuals used to create one or more clade topology
   constraints to meet during the search.

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -1677,10 +1677,15 @@ function optimizegamma_LiNC!(obj::SSM, focusedge::Edge,
         inside01 = false
         ll = wsum((visib ? log.(clikp) : log.(clikp .+ clikn)))
         @debug "γ = 0 best, skip Newton-Raphson"
-    elseif llg0 == 0.0 # if llg0 = 0, keep gamma (otherwise, llg0 = 0 leads to γ = NaN)
-        γ = γ0
-        inside01 = false
-        @debug "llg0 is $llg0, keep current γ, skip Newton-Raphson"
+    elseif llg0 == 0.0 # if llg0 = 0, something fishy is happening.
+        printEdges(obj.net)
+        printNodes(obj.net)
+        @show ulik
+        # γ = γ0
+        # inside01 = false
+        # is there a hybrid node with no tip below?
+        @info "hybrid nodes' children: $([getChildEdge(h) for h in obj.net.hybrid])"
+        @error("llg0 is $llg0. something is odd")
     else # at γ=1
         if visib
              ulik .= (clike .- clikp) ./ clike

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -1,8 +1,8 @@
 # any change to these constants must be documented in phyLiNC!
 const moveweights_LiNC = Distributions.aweights([0.4, 0.2, 0.2, 0.2])
 const movelist_LiNC = ["nni", "addhybrid", "deletehybrid", "root"]
-const likAbsAddHybLiNC = 0.0 #= loglik improvement required to retain a hybrid
-  greater values raise the standard for newly-proposed hybrids,
+const likAbsAddHybLiNC = 0.0 #= loglik improvement required to retain a hybrid.
+  Greater values would raise the standard for newly-proposed hybrids,
   leading to fewer proposed hybrids accepted during the search =#
 const likAbsDelHybLiNC = -0.1 #= loglik decrease allowed when removing a hybrid
   lower (more negative) values of lead to more hybrids removed during the search =#
@@ -1695,19 +1695,7 @@ function optimizegamma_LiNC!(obj::SSM, focusedge::Edge,
         ll = wsum((visib ? log.(clikp) : log.(clikp .+ clikn)))
         @debug "γ = 0 best, skip Newton-Raphson"
     elseif llg0 == 0.0 # if llg0 = 0, something fishy is happening.
-        @show ulik
-        @show visib
-        @show clike
-        @show clikn
-        printEdges(obj.net)
-        printNodes(obj.net)
-        @show hase
-        @show obj.priorltw
-        # γ = γ0
-        # inside01 = false
-        # is there a hybrid node with no tip below?
-        @info "hybrid nodes' children: $([getChildEdge(h) for h in obj.net.hybrid])"
-        @error("llg0 is $llg0. something is odd")
+        @error("llg0 is $llg0 and optimization is proceeding. Something is wrong.")
     else # at γ=1
         if visib
              ulik .= (clike .- clikp) ./ clike
@@ -1720,9 +1708,6 @@ function optimizegamma_LiNC!(obj::SSM, focusedge::Edge,
             @debug "γ = 1 best, skip Newton-Raphson"
         end
     end
-    @debug "before inside01 in optimizegamma:
-            edge $(focusedge.number) starting γ was $γ0. inside01 is $inside01.
-            ll is $ll and llg0 is $llg0 and ulik is $ulik."
     if inside01
     # use interpolation to get a good starting point? γ = llg0 / (llg0 - llg1) in [0,1]
         γ = γ0

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -1347,16 +1347,6 @@ function optimizelength_LiNC!(obj::SSM, focusedge::Edge,
     if getParent(focusedge).hybrid # keep the reticulation unzipped
         return nothing # the length of focus edge should be 0. stay as is.
     end
-    # confirm branch lengths inside bounds #TODO needs to be tested
-    if focusedge.length < BLmin
-        printEdges(obj.net)
-        error("focus edge $(focusedge.number) has length < BLmin: $(focusedge.length)")
-        focusedge.length = BLmin
-    elseif focusedge.length > BLmax
-        printEdges(obj.net)
-        error("focus edge $(focusedge.number) has length > BLmax: $(focusedge.length)")
-        focusedge.length = BLmax
-    end
     cfg = updatecache_edge!(lcache, obj, focusedge)
     ismissing(cfg) && return nothing
     flike  = lcache.flike

--- a/src/traitsLikDiscrete.jl
+++ b/src/traitsLikDiscrete.jl
@@ -78,7 +78,7 @@ mutable struct StatisticalSubstitutionModel <: StatsBase.StatisticalModel
         end
         # T = eltype(getlabels(model))
         # extract displayed trees
-        trees = displayedTrees(net, 0.0; nofuse=true)
+        trees = displayedTrees(net, 0.0; nofuse=true, keeporiginalroot=true)
         for tree in trees
             preorder!(tree) # no need to call directEdges! before: already done on net
         end
@@ -210,11 +210,6 @@ Optional arguments (default):
 - bounds for the alpha parameter of the Gamma distribution of
   rates across sites: `alphamin=0.05`, `alphamax=50`.
 - `verbose` (false): if true, more information is output.
-
-**limitation**: the root is assumed to be in each displayed tree,
-unless the prior at the root is taken to be the stationary distribution.
-This leads to a wrong likelihood if the root had a hybrid child edge.
-fixit in the future, with new option in `deleteleaf!` and to extract displayed trees.
 
 # examples:
 

--- a/src/traitsLikDiscrete.jl
+++ b/src/traitsLikDiscrete.jl
@@ -136,7 +136,7 @@ StatsBase.dof(obj::SSM) = nparams(obj.model) + nparams(obj.ratemodel)
 function Base.show(io::IO, obj::SSM)
     disp =  "$(typeof(obj)):\n"
     disp *= string(obj.model)
-    disp *= "$(obj.nsites) traits, $(length(obj.trait)) species\n"
+    disp *= "$(length(obj.trait)) species, $(obj.totalsiteweight) sites, $(obj.nsites) distinct patterns\n"
     if obj.ratemodel.ncat != 1
         disp *= "variable rates across sites ~ discretized gamma with\n alpha=$(obj.ratemodel.alpha)"
         disp *= "\n $(obj.ratemodel.ncat) categories"

--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -45,11 +45,11 @@ net = readTopology(netstr);
 @test writeTopology(net) == "(Adif:1.0,(Aech:0.122,(Asub:1.0,Agem:1.0):10.0):10.0);"
 net = readTopology(netstr);
 @test_logs PhyloNetworks.deletehybridedge!(net, net.edge[9], true);
-#fixit: if we want to keep a root of degree one, we would need to add an option
-     # to deletehybridedge to truly keep all node. (Currently, it keeps all
-     # nodes that have data below.) If we do this, the correct topology would be:
-     # "((Adif:1.0,(Aech:0.122,((Asub:1.0,Agem:1.0):0.0)H6:10.0):10.0):1.614);"
 @test writeTopology(net) == "(Adif:1.0,(Aech:0.122,((Asub:1.0,Agem:1.0):0.0)H6:10.0):10.0);"
+net = readTopology(netstr);
+@test_logs PhyloNetworks.deletehybridedge!(net, net.edge[9], true, false, false,
+                                           true, true); #keeps root of degree 1
+@test writeTopology(net) == "((Adif:1.0,(Aech:0.122,((Asub:1.0,Agem:1.0):0.0)H6:10.0):10.0):1.614);"
 
 if doalltests
 net=readTopology("(4,((1,(2)#H7:::0.864):2.069,(6,5):3.423):0.265,(3,#H7:::0.1361111):10.0);");

--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -48,7 +48,7 @@ net = readTopology(netstr);
 @test writeTopology(net) == "(Adif:1.0,(Aech:0.122,((Asub:1.0,Agem:1.0):0.0)H6:10.0):10.0);"
 net = readTopology(netstr);
 @test_logs PhyloNetworks.deletehybridedge!(net, net.edge[9], true, false, false,
-                                           true, true); #keeps root of degree 1
+    true, true); # last: keeporiginalroot=true to keep the root of degree 1
 @test writeTopology(net) == "((Adif:1.0,(Aech:0.122,((Asub:1.0,Agem:1.0):0.0)H6:10.0):10.0):1.614);"
 
 if doalltests

--- a/test/test_phyLiNCoptimization.jl
+++ b/test/test_phyLiNCoptimization.jl
@@ -153,7 +153,6 @@ PhyloNetworks.rezip_canonical!(undoinfo...)
 end
 
 @testset "update root in SSM displayed trees" begin
-# testing deleteleaf! with keeporiginalroot=true
 # W structure
 net = readTopology("(C:0.0262,(B:0.0)#H2:0.03::0.9756,(((D:0.1,A:0.1274):0.0)#H1:0.0::0.6,(#H2:0.0001::0.0244,#H1:0.151::0.4):0.0274):0.4812);")
 # "((C:0.0262,(B:0.0)#H2:0.03::0.9756):0.4812,((D:0.1,A:0.1274):0.0)#H1:0.0::0.6,(#H2:0.0001::0.0244,#H1:0.151::0.4):0.0274);")
@@ -165,9 +164,8 @@ obj = PhyloNetworks.StatisticalSubstitutionModel(net, fastasimple, :JC69)
 rootatnode!(obj.net, 7) # node 7 = tree node whose 2 children are both hybrids
 # "(#H2:0.0001::0.0244,((C:0.0262,(B:0.0)#H2:0.03::0.9756):0.4812,((D:0.1,A:0.1274):0.0)#H1:0.0::0.6):0.0274,#H1:0.151);"
 PhyloNetworks.updateSSM_root!(obj) # re-root displayed trees in the same way
-@test [t.node[t.root].number for t in obj.displayedtree] == [7,7,7,7] #NOT 6,7,7,7
-@test writeTopology(obj.displayedtree[1]) == "((((D:0.1,A:0.1274):0.0)H1:0.0,(C:0.0262,(B:0.0)H2:0.03):0.4812):0.0274);"
-# not this "(((D:0.1,A:0.1274):0.0)H1:0.0,(C:0.0262,(B:0.0)H2:0.03):0.4812);"
+@test [t.node[t.root].number for t in obj.displayedtree] == [6,7,7,7]
+@test writeTopology(obj.displayedtree[1]) == "(((D:0.1,A:0.1274):0.0)H1:0.0,(C:0.0262,(B:0.0)H2:0.03):0.4812);"
 end
 
 @testset "optimizestructure with simple example" begin

--- a/test/test_phyLiNCoptimization.jl
+++ b/test/test_phyLiNCoptimization.jl
@@ -153,6 +153,7 @@ PhyloNetworks.rezip_canonical!(undoinfo...)
 end
 
 @testset "update root in SSM displayed trees" begin
+# testing deleteleaf! with keeporiginalroot=true
 # W structure
 net = readTopology("(C:0.0262,(B:0.0)#H2:0.03::0.9756,(((D:0.1,A:0.1274):0.0)#H1:0.0::0.6,(#H2:0.0001::0.0244,#H1:0.151::0.4):0.0274):0.4812);")
 # "((C:0.0262,(B:0.0)#H2:0.03::0.9756):0.4812,((D:0.1,A:0.1274):0.0)#H1:0.0::0.6,(#H2:0.0001::0.0244,#H1:0.151::0.4):0.0274);")
@@ -164,8 +165,9 @@ obj = PhyloNetworks.StatisticalSubstitutionModel(net, fastasimple, :JC69)
 rootatnode!(obj.net, 7) # node 7 = tree node whose 2 children are both hybrids
 # "(#H2:0.0001::0.0244,((C:0.0262,(B:0.0)#H2:0.03::0.9756):0.4812,((D:0.1,A:0.1274):0.0)#H1:0.0::0.6):0.0274,#H1:0.151);"
 PhyloNetworks.updateSSM_root!(obj) # re-root displayed trees in the same way
-@test [t.node[t.root].number for t in obj.displayedtree] == [6,7,7,7]
-@test writeTopology(obj.displayedtree[1]) == "(((D:0.1,A:0.1274):0.0)H1:0.0,(C:0.0262,(B:0.0)H2:0.03):0.4812);"
+@test [t.node[t.root].number for t in obj.displayedtree] == [7,7,7,7] #NOT 6,7,7,7
+@test writeTopology(obj.displayedtree[1]) == "((((D:0.1,A:0.1274):0.0)H1:0.0,(C:0.0262,(B:0.0)H2:0.03):0.4812):0.0274);"
+# not this "(((D:0.1,A:0.1274):0.0)H1:0.0,(C:0.0262,(B:0.0)H2:0.03):0.4812);"
 end
 
 @testset "optimizestructure with simple example" begin

--- a/test/test_phyLiNCoptimization.jl
+++ b/test/test_phyLiNCoptimization.jl
@@ -168,6 +168,28 @@ PhyloNetworks.updateSSM_root!(obj) # re-root displayed trees in the same way
 @test writeTopology(obj.displayedtree[1]) == "(((D:0.1,A:0.1274):0.0)H1:0.0,(C:0.0262,(B:0.0)H2:0.03):0.4812);"
 end
 
+@testset "skip γ and lengths optimization when needed" begin
+# W structure, with middle γs = 0
+net = readTopology("(C:0.0262,(B:0.0)#H2:0.03::1,(((D:0.1,A:0.1274):0.0)#H1:0.004::1,(#H2:0.0001,#H1:0.151):0.0274):0.4812);")
+obj = PhyloNetworks.StatisticalSubstitutionModel(net, fastasimple, :JC69)
+for i in [8,9] setGamma!(obj.net.edge[i], 0.0); end
+PhyloNetworks.updateSSM!(obj)
+lcache = PhyloNetworks.CacheLengthLiNC(obj, 1e-6,1e-6,1e-2,1e-3, 5);
+e = PhyloNetworks.optimizelocalBL_LiNC!(obj, obj.net.edge[10], lcache)
+@test length(e) == 3 # not 5: the 2 edges with γ = 0 were excluded
+@test obj.net.edge[10].length == 0.0274
+# hybrid ladder, with lower γ = 0
+net = readTopology("(#H2:0.0001::0.0244,((C:0.0262,((B:0.0)#H1:0.0::0.6)#H2:0.03::0.9756):0.4812,(#H1:0.0001::0.4,A:0.1274):0.0001):0.0274,D:0.151);")
+obj = PhyloNetworks.StatisticalSubstitutionModel(net, fastasimple, :JC69)
+setGamma!(obj.net.edge[4], 0.0); PhyloNetworks.updateSSM!(obj)
+e = PhyloNetworks.optimizelocalBL_LiNC!(obj, obj.net.edge[5], lcache)
+@test length(e) == 4
+@test [obj.net.edge[i].length for i in [1,5]] == [0.0001, 0.03]
+γcache = PhyloNetworks.CacheGammaLiNC(obj);
+ll = PhyloNetworks.optimizegamma_LiNC!(obj, obj.net.edge[5], .001, γcache, 3)
+@test ll ≈ -31.124547305074074 # same as before optimization
+end
+
 @testset "optimizestructure with simple example" begin
 net = readTopology("(((A:2.0,(B:1.0)#H1:0.1::0.9):1.5,(C:0.6,#H1:1.0::0.1):1.0):0.5,D:2.0);")
 obj = PhyloNetworks.StatisticalSubstitutionModel(net, fastasimple, :JC69, 1)


### PR DESCRIPTION
- moves root when root doesn't appear in a displayed tree
- fixed NaN gamma bug by preventing branch length optimization on edges with gamma = 0.0
- fixed out of bounds branch length
- gamma becomes NaN when llg0 == 0.0. In this case, set γ = γ0.

data set 1: ERROR found on PhyLiNC for run 3 seed 34651:
the root's children are all hybrids: there must be a 2-cycle...