### PR TITLE
implementing multivariate BM process

### DIFF
--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -108,6 +108,7 @@ module PhyloNetworks
         simulate,
         TraitSimulation,
         ParamsBM,
+        ParamsMultiBM,
         ShiftNet,
         shiftHybrid,
         getShiftEdgeNumber,

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -859,7 +859,7 @@ end
 
 Type for a BM process on a network. Fields are `mu` (expectation),
 `sigma2` (variance), `randomRoot` (whether the root is random, default to `false`),
-and `varRoot` (if the root is random, the variance of the root, defalut to `NaN`).
+and `varRoot` (if the root is random, the variance of the root, default to `NaN`).
 
 """
 mutable struct ParamsBM <: ParamsProcess

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -937,7 +937,6 @@ end
 
 function anyShift(params::ParamsMultiBM)
     # TODO
-    @warn "Shifts not currently implemented. Returning false."
     return false
 end
 
@@ -1168,7 +1167,7 @@ function updateTreeSimulateMBD!(M::Matrix{Float64},
 
     means[:, i] .= means[:, parentIndex]# expectation
     vals[:, i] .= vals[:, parentIndex] + sqrt(edge.length) * params.L * randn(p) # random value #TODO: make memory efficient
-    # TODO: add shifts
+    # TODO: shifts
 end
 
 
@@ -1202,7 +1201,7 @@ function updateHybridSimulateMBD!(M::Matrix{Float64},
     means[:, i] .= edge1.gamma * means[:, parentIndex1] + edge2.gamma * means[:, parentIndex2] # expectation
     vals[:, i] .=  edge1.gamma * (vals[:, parentIndex1] + sqrt(edge1.length) * params.L * randn(p)) +
                     edge2.gamma * (vals[:, parentIndex2] + sqrt(edge2.length) * params.L * randn(p)) # random value
-    # TODO: shifts?
+    # TODO: shifts
     # TODO: memory efficincy
 end
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -820,6 +820,8 @@ shiftHybrid(value::Real, net::HybridNetwork; checkPreorder=true::Bool) = shiftHy
     getShiftEdgeNumber(shift::ShiftNet)
 
 Get the edge numbers where the shifts are located, for an object [`ShiftNet`](@ref).
+If a shift is placed at the root node with no parent edge, the edge number
+of a shift is set to -1 (as if missing).
 """
 function getShiftEdgeNumber(shift::ShiftNet)
     nodInd = getShiftRowInds(shift)
@@ -1179,7 +1181,26 @@ julia> traits = sim[:Tips] # Extract simulated values at the tips.
   2.8051193818084057
   3.1910928691142915
 
-julia> traits = sim[:InternalNodes] # Extract simulated values at internal nodes.
+julia> sim.M.tipNames # name of tips, in the same order as values above
+16-element Array{String,1}:
+ "Prionodontidae"
+ "Felidae"
+ "Viverridae"
+ "Herpestidae"
+ "Eupleridae"
+ "Hyaenidae"
+ "Nandiniidae"
+ "Canidae"
+ "Ursidae"
+ "Odobenidae"
+ "Otariidae"
+ "Phocidae"
+ "Mephitidae"
+ "Ailuridae"
+ "Mustelidae"
+ "Procyonidae"
+
+julia> traits = sim[:InternalNodes] # Extract simulated values at internal nodes. Order: as in sim.M.internalNodeNumbers
 15-element Array{Float64,1}:
  1.1754592873593104
  2.0953234045227083
@@ -1197,7 +1218,7 @@ julia> traits = sim[:InternalNodes] # Extract simulated values at internal nodes
  2.4579867601968663
  1.0
 
-julia> traits = sim[:All] # Extract simulated values at all nodes in the network.
+julia> traits = sim[:All] # simulated values at all nodes, ordered as in sim.M.nodeNumbersTopOrder
 31-element Array{Float64,1}:
  1.0
  2.4579867601968663
@@ -1264,12 +1285,12 @@ julia> traits = sim[:Tips] # Extract simulated values at the tips (each column c
  5.39465  7.223     1.88036  -5.10491   …  -3.86504  0.133704  -2.44564
  7.29184  7.59947  -1.89206  -0.960013      3.86822  3.23285    1.93376
 
-julia> traits = sim[:InternalNodes] # Extract simulated values at internal nodes
+julia> traits = sim[:InternalNodes] # simulated values at internal nodes. order: same as in sim.M.internalNodeNumbers
 2×15 Array{Float64,2}:
  4.42499  -0.364198  0.71666   3.76669  …  4.57552  4.29265  5.61056  1.0
  6.24238   2.97237   0.698006  2.40122     5.92623  5.13753  4.5268   2.0
 
-julia> traits = sim[:All] # Extract simulated values at all nodes
+julia> traits = sim[:All] # simulated values at all nodes, ordered as in sim.M.nodeNumbersTopOrder
 2×31 Array{Float64,2}:
  1.0  5.61056  4.29265  4.57552  …   1.88036  4.42499  7.223    5.39465
  2.0  4.5268   5.13753  5.92623     -1.89206  6.24238  7.59947  7.29184

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1192,14 +1192,14 @@ function simulate(net::HybridNetwork,
 end
 
 
-function preorderFunctions(params::ParamsBM)
+function preorderFunctions(::ParamsBM)
     return Dict("init" => initSimulateBM,
                 "root" => updateRootSimulateBM!,
                 "tree" => updateTreeSimulateBM!,
                 "hybrid" => updateHybridSimulateBM!)
 end
 
-function preorderFunctions(params::ParamsMultiBM)
+function preorderFunctions(::ParamsMultiBM)
     return Dict("init" => initSimulateMBD,
                 "root" => updateRootSimulateMBD!,
                 "tree" => updateTreeSimulateMBD!,
@@ -1209,7 +1209,7 @@ end
 
 
 # Initialization of the structure
-function initSimulateBM(nodes::Vector{Node}, params::Tuple{ParamsBM})
+function initSimulateBM(nodes::Vector{Node}, ::Tuple{ParamsBM})
     return(zeros(2, length(nodes)))
 end
 
@@ -1357,7 +1357,7 @@ function Base.getindex(obj::TraitSimulation, d::Symbol, w=:Sim::Symbol)
     return getindex(obj.M, d)[inds, :]
 end
 
-function siminds(params::ParamsBM, w::Symbol)
+function siminds(::ParamsBM, w::Symbol)
     if w == :Sim
         return 2
     elseif w == :Exp

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -916,7 +916,7 @@ Type for a multivariate Brownian diffusion (MBD) process on a network. Fields ar
 and `L` (the lower triangular of the cholesky decomposition of `sigma`, computed automatically)
 
 """
-struct ParamsMultiBM <: ParamsProcess
+mutable struct ParamsMultiBM <: ParamsProcess
     mu::AbstractArray{Float64, 1}
     sigma::AbstractArray{Float64, 2}
     randomRoot::Bool
@@ -928,6 +928,8 @@ end
 ParamsMultiBM(mu::AbstractArray{Float64, 1},
                 sigma::AbstractArray{Float64, 2}) =
         ParamsMultiBM(mu, sigma, false, Diagonal([NaN]), missing, cholesky(sigma).L)
+
+# TODO: add more constructors
 
 
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1139,7 +1139,7 @@ function updateRootSimulateMBD!(M::Matrix{Float64},
 
     if (params.randomRoot)
         means[:, i] .= params.mu # expectation
-        vals[:, i] .= params.mu + params.L * randn(p) # random value #TODO: make memory efficient
+        vals[:, i] .= params.mu + cholesky(params.varRoot).L * randn(p) # random value #TODO: make memory efficient
     else
         means[:, i] .= params.mu # expectation
         vals[:, i] .= params.mu # random value

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -2608,6 +2608,30 @@ function updateHybridSimulateMBD!(M::Matrix{Float64},
     # TODO: memory efficincy
 end
 
+function Base.show(io::IO, obj::ParamsMultiBM)
+    disp =  "$(typeof(obj)):\n"
+    pt = paramstable(obj)
+    if obj.randomRoot
+        disp = disp * "Parameters of a BM with random root:\n" * pt
+    else
+        disp = disp * "Parameters of a BM with fixed root:\n" * pt
+    end
+    println(io, disp)
+end
+
+function paramstable(obj::ParamsMultiBM)
+    disp = "mu: $(obj.mu)\nSigma: $(obj.sigma)"
+    if obj.randomRoot
+        disp = disp * "\nvarRoot: $(obj.varRoot)"
+    end
+    if anyShift(obj)
+        disp = disp * "\n\nThere are $(length(getShiftValue(obj.shift))) shifts on the network:\n"
+        disp = disp * "$(shiftTable(obj.shift))"
+    end
+    return(disp)
+end
+
+
 
 
 #################################################

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -976,6 +976,34 @@ Type for a multivariate Brownian diffusion (MBD) process on a network. Fields ar
 `shift` (a ShiftNet type, default to `missing`),
 and `L` (the lower triangular of the cholesky decomposition of `sigma`, computed automatically)
 
+# Constructors
+```jldoctest
+julia> ParamsMultiBM([1.0, -0.5], [2.0 0.3; 0.3 1.0]) # no shifts
+ParamsMultiBM:
+Parameters of a MBD with fixed root:
+mu: [1.0, -0.5]
+Sigma: [2.0 0.3; 0.3 1.0]
+
+julia> net = readTopology("((A:1,B:1):1,C:2);");
+
+julia> shifts = ShiftNet(net.node[2], [-1.0, 2.0], net);
+
+julia> ParamsMultiBM([1.0, -0.5], [2.0 0.3; 0.3 1.0], shifts) # with shifts
+ParamsMultiBM:
+Parameters of a MBD with fixed root:
+mu: [1.0, -0.5]
+Sigma: [2.0 0.3; 0.3 1.0]
+
+There are 2 shifts on the network:
+───────────────────────────────────────────
+  Edge Number  Shift Value 1  Shift Value 2
+───────────────────────────────────────────
+          2.0           -1.0            2.0
+───────────────────────────────────────────
+
+
+```
+
 """
 mutable struct ParamsMultiBM <: ParamsProcess
     mu::AbstractArray{Float64, 1}

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -905,8 +905,17 @@ function paramstable(obj::ParamsBM)
     return(disp)
 end
 
-## ParamsMultiBM
 
+"""
+    ParamsMultiBM <: ParamsProcess
+
+Type for a multivariate Brownian diffusion (MBD) process on a network. Fields are `mu` (expectation),
+`sigma` (covariance matrix), `randomRoot` (whether the root is random, default to `false`),
+`varRoot` (if the root is random, the covariance matrix of the root, default to `[NaN]`),
+`shift` (a ShiftNet type, default to `missing`),
+and `L` (the lower triangular of the cholesky decomposition of `sigma`, computed automatically)
+
+"""
 mutable struct ParamsMultiBM <: ParamsProcess
     mu::AbstractArray{Float64, 1}
     sigma::AbstractArray{Float64, 2}

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1383,8 +1383,18 @@ function updateTreeSimulateMBD!(M::Matrix{Float64},
 
     means, vals = partitionMBDMatrix(M, p)
 
-    means[:, i] .= means[:, parentIndex] + params.shift.shift[i, :]
-    vals[:, i] .= vals[:, parentIndex] + params.shift.shift[i, :] + sqrt(edge.length) * params.L * randn(p) # random value #TODO: make memory efficient
+    μ = @view means[:, i]
+    val = @view vals[:, i]
+
+    # μ .= means[:, parentIndex] + params.shift.shift[i, :]
+    μ .= @view means[:, parentIndex]
+    μ .+= @view params.shift.shift[i, :]
+
+    # val .= sqrt(edge.length) * params.L * randn(p) + vals[:, parentIndex] + params.shift.shift[i, :]
+    mul!(val, params.L, randn(p))
+    val .*= sqrt(edge.length)
+    val .+= @view vals[:, parentIndex]
+    val .+= params.shift.shift[i, :]
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,7 +86,7 @@ tests = [
     "test_bootstrap.jl",
     "test_perfectData.jl", # "test_readme.jl"
     "test_moves_semidirected.jl",
-    "test_lm.jl", "test_lm_tree.jl", "test_traits.jl", "test_simulate.jl",
+    "test_lm.jl", "test_lm_tree.jl", "test_traits.jl", "test_simulate.jl", "test_simulate_mbd.jl",
     "test_parsimony.jl",
     "test_calibratePairwise.jl", "test_relaxed_reading.jl",
     "test_isMajor.jl", "test_interop.jl",

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -13,6 +13,7 @@ pars = ParamsBM(1, 0.1); # params of a BM
 
 sim = simulate(net, pars); # simulate according to a BM
 @test_logs show(devnull, sim)
+@test_throws ErrorException sim[:Tips, :Broken]
 
 # Extract simulated values
 traitsTips = sim[:Tips];

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -80,7 +80,7 @@ sh1 = ShiftNet(net.node[7], 3.0,  net)*ShiftNet(net.node[9], -2.1,  net)
 ## Values and edge numbers functions
 sh = ShiftNet(net.node[7], 3.0,  net)
 @test getShiftEdgeNumber(sh) == [8]
-@test getShiftValue(sh) == [3.0]
+@test all(getShiftValue(sh) .== [3.0])
 
 ## Hybrid shifts
 @test shiftHybrid([2.0], net).shift ≈ ShiftNet(net.edge[6], 2.0, net).shift

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -118,6 +118,7 @@ traitsNodesExp = [1.50594336537754 3.296894371572107 4.346436961253621 1.3212328
 
 ## Generate some values
 Random.seed!(18480224); # fix the seed
+@test_throws ErrorException ParamsBM(1, 0.1, ShiftNet(net.edge[8], [3.0, 1.0],  net))
 pars = ParamsBM(1, 0.1, ShiftNet(net.edge[8], 3.0,  net)); # params of a BM
 N = 50000
 S = length(tipLabels(net));

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -90,6 +90,9 @@ sh = ShiftNet(net.node[7], 3.0,  net)
 
 ## Test simulate
 
+# No shift on root
+@test_throws ErrorException simulate(net, ParamsBM(1.0, 0.1, ShiftNet(net.node[9], 3.0,  net)))
+
 @test ParamsBM(1.0, 1.0, net).shift.shift ≈ ParamsBM(1.0, 1.0, ShiftNet(net)).shift.shift
 
 pars = ParamsBM(1, 0.1, ShiftNet(net.edge[8], 3.0,  net)); # params of a BM
@@ -117,6 +120,12 @@ traitsNodesExp = [1.50594336537754 3.296894371572107 4.346436961253621 1.3212328
 @test traitsNodes ≈ traitsNodesExp
 @test meansTips ≈ meansTipsExp
 @test meansNodes ≈ meansNodesExp
+
+# Test same as MultiBM
+pars = ParamsMultiBM([1.0], 0.1*ones(1,1), ShiftNet(net.edge[8], 3.0,  net));
+simMulti = simulate(net, pars); 
+@test simMulti[:Tips, :Exp] ≈ sim[:Tips, :Exp]'
+@test simMulti[:InternalNodes, :Exp] ≈ sim[:InternalNodes, :Exp]'
 
 ###############################################################################
 ## Test of distibution - with shifts

--- a/test/test_simulate.jl
+++ b/test/test_simulate.jl
@@ -67,6 +67,7 @@ net = readTopology("(A:2.5,((B:1,#H1:0.5::0.4):1,(C:1,(D:0.5)#H1:0.5::0.6):1):0.
 ## Test construction function
 @test_throws ErrorException ShiftNet(net.edge[7], 3.0,  net) # can't put a shift on hybrid branch
 @test_throws ErrorException ShiftNet(net.node[6], 3.0,  net) # can't put a shift on hybrid branch
+@test ShiftNet(net).shift ≈ zeros(length(net.node))
 @test ShiftNet(net.edge[8], 3.0,  net).shift ≈ ShiftNet([net.edge[8]], [3.0],  net).shift
 @test ShiftNet(net.edge[8], 3.0,  net).shift ≈ ShiftNet(net.node[7], 3.0,  net).shift
 @test ShiftNet(net.node[7], 3.0,  net).shift ≈ ShiftNet([net.node[7]], [3.0],  net).shift
@@ -84,8 +85,12 @@ sh = ShiftNet(net.node[7], 3.0,  net)
 
 ## Hybrid shifts
 @test shiftHybrid([2.0], net).shift ≈ ShiftNet(net.edge[6], 2.0, net).shift
+@test shiftHybrid(2.0, net).shift ≈ shiftHybrid([2.0], net).shift
 
 ## Test simulate
+
+@test ParamsBM(1.0, 1.0, net).shift.shift ≈ ParamsBM(1.0, 1.0, ShiftNet(net)).shift.shift
+
 pars = ParamsBM(1, 0.1, ShiftNet(net.edge[8], 3.0,  net)); # params of a BM
 @test_logs show(devnull, pars)
 @test_logs show(devnull, pars.shift)

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -1,14 +1,16 @@
 # Tests to simulate multivariate traits
 
-using PhyloNetworks, LinearAlgebra, Test
-import Random
-
-## Get a network and make it ultrametric
+## Get an ultrametric network ('net' already in global scope)
 net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");
-trait_dim = 3
-
 
 @testset "Simulate data and check means and dimensions" begin
+
+# one single trait
+pars = ParamsMultiBM([5.0], ones(1,1))
+sim = simulate(net, pars)
+@test sim[:Tips, :Exp] == [5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0 5.0]
+
+trait_dim = 3
 
 ## Simulate a MBD
 Random.seed!(17920921); # fix the seed
@@ -34,11 +36,8 @@ traitsNodes = sim[:InternalNodes];
 @test size(traitsTips) == (trait_dim, net.numTaxa)
 @test size(traitsNodes) == (trait_dim, net.numNodes - net.numTaxa)
 
-expectations = sim[:All, :Exp]
-
 # Check means (no shifts)
-max_diff = maximum(expectations - μ * ones(net.numNodes)')
-@test max_diff ≈ 0.0 atol=1e-10
+@test sim[:All, :Exp] ≈ μ * ones(net.numNodes)'
 
 end
 
@@ -46,6 +45,7 @@ end
 ## Test of distibution (fixed root)
 ###############################################################################
 @testset "Simulate test distribution (fixed root)" begin
+trait_dim = 3
 
 ## Generate some values
 Random.seed!(18480224); # fix the seed
@@ -54,7 +54,7 @@ Random.seed!(18480224); # fix the seed
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
 
-N = 50000
+N = 10000
 S = length(tipLabels(net));
 μ_sim = zeros(trait_dim, S)
 Σ_sim = zeros(trait_dim * S, trait_dim * S)
@@ -62,27 +62,20 @@ for i = 1:N
     tips = simulate(net, pars)[:Tips]
     μ_sim .+= tips
     v_sim = vec(tips)
-    Σ_sim += v_sim * v_sim'
+    Σ_sim .+= v_sim * v_sim'
 end
-
 μ_sim ./= N
 Σ_sim ./= N
 Σ_sim = Σ_sim - vec(μ_sim) * vec(μ_sim)'
 
 ## Check means
-
 μ_true = μ * ones(S)'
-
-μ_max = maximum(abs.(μ_true - μ_sim))
-@test μ_max < 1e-1
+@test isapprox(μ_sim, μ_true, atol=0.2)
 
 ## Check covariance
-
 Ψ = Matrix(vcv(net))
 Σ_true = kron(Ψ, Σ)
-Σ_max = maximum(abs.(Σ_true - Σ_sim))
-@test Σ_max < 2e-1
-
+@test isapprox(Σ_sim, Σ_true, atol=3.0) # norm L2 of 36x36 matrix
 
 end
 
@@ -90,6 +83,7 @@ end
 ## Test of distibution (random root)
 ###############################################################################
 @testset "Simulate test distribution (random root)" begin
+trait_dim = 3
 
 ## Generate some values
 Random.seed!(24452384); # fix the seed
@@ -97,7 +91,6 @@ Random.seed!(24452384); # fix the seed
 Σ = randn(trait_dim, trait_dim)
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
-
 
 Σ_root = randn(trait_dim, trait_dim)
 Σ_root = Σ_root * Σ_root' / 10.0 # needs to be positive definite (and not too big to reduce variance in test)
@@ -107,7 +100,7 @@ pars.randomRoot = true
 @test_logs show(devnull, pars)
 show(devnull, pars)
 
-N = 50000
+N = 10000
 S = length(tipLabels(net));
 μ_sim = zeros(trait_dim, S)
 Σ_sim = zeros(trait_dim * S, trait_dim * S)
@@ -115,28 +108,19 @@ for i = 1:N
     tips = simulate(net, pars)[:Tips]
     μ_sim .+= tips
     v_sim = vec(tips)
-    Σ_sim += v_sim * v_sim'
+    Σ_sim .+= v_sim * v_sim'
 end
-
 μ_sim ./= N
 Σ_sim ./= N
 Σ_sim = Σ_sim - vec(μ_sim) * vec(μ_sim)'
 
 ## Check means
-
-μ_true = μ * ones(S)'
-
-μ_max = maximum(abs.(μ_true - μ_sim))
-@test μ_max < 1e-1
+@test isapprox(μ_sim, μ * ones(S)', atol=0.2)
 
 ## Check covariance
-
 Ψ = Matrix(vcv(net))
 Σ_true = kron(Ψ, Σ) + kron(ones(S, S), pars.varRoot)
-Σ_max = maximum(abs.(Σ_true - Σ_sim))
-# @show Σ_max
-@test Σ_max < 2e-1
-
+@test isapprox(Σ_sim, Σ_true, atol=3.6) # norm L2 of 36x36 matrix
 
 end
 
@@ -145,12 +129,12 @@ end
 ## With shifts
 ################################################################################
 
+net = readTopology("(A:2.5,((B:1,#H1:0.5::0.4):1,(C:1,(D:0.5)#H1:0.5::0.6):1):0.5);")
+
 @testset "Simulate with Shifts" begin
+trait_dim = 3
 
 Random.seed!(275698234545); # fix the seed
-
-global net
-net = readTopology("(A:2.5,((B:1,#H1:0.5::0.4):1,(C:1,(D:0.5)#H1:0.5::0.6):1):0.5);")
 
 ## Test construction function
 @test_throws ErrorException ShiftNet(net.edge[7], [1.0, 2.0],  net) # can't put a shift on hybrid branch
@@ -168,7 +152,6 @@ sh1 = ShiftNet(net.node[7], [1.0, 2.0],  net)*ShiftNet(net.node[9], [3.0, -1.5],
 @test sh1.shift ≈ (sh1*ShiftNet([net.node[7]], [1.0 2.0],  net)).shift
 @test_throws ErrorException sh1*ShiftNet(net.edge[8], [4.0, 3.5, 5.0],  net) # can't concatenate if the two affect the same edges
 
-
 ## Values and edge numbers functions
 @test getShiftEdgeNumber(sh1) == [-1, 8]
 @test getShiftValue(sh1) == [3.0 -1.5; 1.0 2.0]
@@ -178,23 +161,22 @@ sh1 = ShiftNet(net.node[7], [1.0, 2.0],  net)*ShiftNet(net.node[9], [3.0, -1.5],
 @test_throws ErrorException shiftHybrid([4.5 2.0; 3.0 5.0], net) # dimension mismatch
 
 ## Distributions
-
 μ = randn(trait_dim)
 Σ = randn(trait_dim, trait_dim)
 Σ = Σ * Σ' # needs to be positive definite
 
 @test ParamsMultiBM(μ, Σ, net).shift.shift ≈ ParamsMultiBM(μ, Σ, ShiftNet(net, trait_dim)).shift.shift
 @test_throws ErrorException ParamsMultiBM(μ, Σ, ShiftNet(net, 1))
-
+# below: the shift at the root, net.node[9], is not used by the simulation
+# It doesn't even affect the mean μ
 sh = ShiftNet(net.node[7], [1.0, 2.0, -1.0],  net)*ShiftNet(net.node[9], [3.0, -1.5, 4.2],  net)
-
 
 pars = ParamsMultiBM(μ, Σ, sh)
 
 @test_logs show(devnull, pars)
 show(devnull, pars)
 
-N = 50000
+N = 10000
 S = length(tipLabels(net));
 μ_sim = zeros(trait_dim, S)
 Σ_sim = zeros(trait_dim * S, trait_dim * S)
@@ -202,9 +184,8 @@ for i = 1:N
     tips = simulate(net, pars)[:Tips]
     μ_sim .+= tips
     v_sim = vec(tips)
-    Σ_sim += v_sim * v_sim'
+    Σ_sim .+= v_sim * v_sim'
 end
-
 μ_sim ./= N
 Σ_sim ./= N
 Σ_sim = Σ_sim - vec(μ_sim) * vec(μ_sim)'
@@ -212,17 +193,11 @@ end
 ## Check means
 sim = simulate(net, pars)
 μ_true = sim[:Tips, :Exp]
-
-μ_max = maximum(abs.(μ_true - μ_sim))
-# @show μ_max
-@test μ_max < 1e-1
+@test μ_true ≈ μ .+ [0 0 1 0.6; 0 0 2 1.2; 0 0 -1 -.6] # from shift on edge 8 only
+@test isapprox(μ_sim, μ_true, atol=0.2)
 
 ## Check covariance
-
 Ψ = Matrix(vcv(net))
 Σ_true = kron(Ψ, Σ)
-Σ_max = maximum(abs.(Σ_true - Σ_sim))
-@test Σ_max < 2e-1
-
-
+@test isapprox(Σ_sim, Σ_true, norm = x -> maximum(abs.(x)), atol=0.4)
 end

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -1,7 +1,7 @@
 # Tests to simulate multivariate traits
 
-# using PhyloNetworks, LinearAlgebra, Test
-# import Random
+using PhyloNetworks, LinearAlgebra, Test
+import Random
 
 ## Get a network and make it ultrametric
 net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");
@@ -24,6 +24,7 @@ pars = ParamsMultiBM(μ, Σ); # params of a MBD
 
 sim = simulate(net, pars); # simulate according to a BM
 @test_logs show(devnull, sim)
+@test_throws ErrorException sim[:Tips, :Broken]
 
 # Extract simulated values
 traitsTips = sim[:Tips];
@@ -104,7 +105,7 @@ pars.varRoot = Σ_root
 pars.randomRoot = true
 
 @test_logs show(devnull, pars)
-show(pars)
+show(devnull, pars)
 
 N = 50000
 S = length(tipLabels(net));
@@ -133,7 +134,7 @@ end
 Ψ = Matrix(vcv(net))
 Σ_true = kron(Ψ, Σ) + kron(ones(S, S), pars.varRoot)
 Σ_max = maximum(abs.(Σ_true - Σ_sim))
-@show Σ_max
+# @show Σ_max
 @test Σ_max < 2e-1
 
 
@@ -185,10 +186,13 @@ sh1 = ShiftNet(net.node[7], [1.0, 2.0],  net)*ShiftNet(net.node[9], [3.0, -1.5],
 @test ParamsMultiBM(μ, Σ, net).shift.shift ≈ ParamsMultiBM(μ, Σ, ShiftNet(net, trait_dim)).shift.shift
 @test_throws ErrorException ParamsMultiBM(μ, Σ, ShiftNet(net, 1))
 
-pars = ParamsMultiBM(μ, Σ, net)
+sh = ShiftNet(net.node[7], [1.0, 2.0, -1.0],  net)*ShiftNet(net.node[9], [3.0, -1.5, 4.2],  net)
+
+
+pars = ParamsMultiBM(μ, Σ, sh)
 
 @test_logs show(devnull, pars)
-show(pars)
+show(devnull, pars)
 
 N = 50000
 S = length(tipLabels(net));
@@ -210,7 +214,7 @@ sim = simulate(net, pars)
 μ_true = sim[:Tips, :Exp]
 
 μ_max = maximum(abs.(μ_true - μ_sim))
-@show μ_max
+# @show μ_max
 @test μ_max < 1e-1
 
 ## Check covariance

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -167,10 +167,14 @@ sh1 = ShiftNet(net.node[7], [1.0, 2.0],  net)*ShiftNet(net.node[9], [3.0, -1.5],
 
 @test ParamsMultiBM(μ, Σ, net).shift.shift ≈ ParamsMultiBM(μ, Σ, ShiftNet(net, trait_dim)).shift.shift
 @test_throws ErrorException ParamsMultiBM(μ, Σ, ShiftNet(net, 1))
-# below: the shift at the root, net.node[9], is not used by the simulation
-# It doesn't even affect the mean μ
-sh = ShiftNet(net.node[7], [1.0, 2.0, -1.0],  net)*ShiftNet(net.node[9], [3.0, -1.5, 4.2],  net)
 
+# Shift at root causes an error.
+sh = ShiftNet(net.node[7], [1.0, 2.0, -1.0],  net)*ShiftNet(net.node[9], [3.0, -1.5, 4.2],  net)
+pars = ParamsMultiBM(μ, Σ, sh)
+@test_throws ErrorException simulate(net, pars)
+
+# One shift, not at the root
+sh = ShiftNet(net.node[7], [1.0, 2.0, -1.0],  net)
 pars = ParamsMultiBM(μ, Σ, sh)
 
 @test_logs show(devnull, pars)

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -2,15 +2,15 @@
 
 ## Get a network and make it ultrametric
 net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");
-P = 3
+trait_dim = 3
 
 
 @testset "Simulate data and check means and dimensions" begin
 
 ## Simulate a MBD
 Random.seed!(17920921); # fix the seed
-μ = randn(P)
-Σ = randn(P, P)
+μ = randn(trait_dim)
+Σ = randn(trait_dim, trait_dim)
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
 @test_logs show(devnull, pars)
@@ -23,8 +23,8 @@ traitsTips = sim[:Tips];
 traitsNodes = sim[:InternalNodes];
 
 # Check dimensions
-@test size(traitsTips) == (P, net.numTaxa)
-@test size(traitsNodes) == (P, net.numNodes - net.numTaxa)
+@test size(traitsTips) == (trait_dim, net.numTaxa)
+@test size(traitsNodes) == (trait_dim, net.numNodes - net.numTaxa)
 
 expectations = sim[:All, :Exp]
 
@@ -41,15 +41,15 @@ end
 
 ## Generate some values
 Random.seed!(18480224); # fix the seed
-μ = randn(P)
-Σ = randn(P, P)
+μ = randn(trait_dim)
+Σ = randn(trait_dim, trait_dim)
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
 
 N = 50000
 S = length(tipLabels(net));
-μ_sim = zeros(P, S)
-Σ_sim = zeros(P * S, P * S)
+μ_sim = zeros(trait_dim, S)
+Σ_sim = zeros(trait_dim * S, trait_dim * S)
 for i = 1:N
     tips = simulate(net, pars)[:Tips]
     μ_sim .+= tips

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -97,12 +97,14 @@ Random.seed!(24452384); # fix the seed
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
 
-@test_logs show(devnull, pars)
 
 Σ_root = randn(trait_dim, trait_dim)
 Σ_root = Σ_root * Σ_root' / 10.0 # needs to be positive definite (and not too big to reduce variance in test)
 pars.varRoot = Σ_root
 pars.randomRoot = true
+
+@test_logs show(devnull, pars)
+show(pars)
 
 N = 50000
 S = length(tipLabels(net));
@@ -184,6 +186,9 @@ sh1 = ShiftNet(net.node[7], [1.0, 2.0],  net)*ShiftNet(net.node[9], [3.0, -1.5],
 @test_throws ErrorException ParamsMultiBM(μ, Σ, ShiftNet(net, 1))
 
 pars = ParamsMultiBM(μ, Σ, net)
+
+@test_logs show(devnull, pars)
+show(pars)
 
 N = 50000
 S = length(tipLabels(net));

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -1,7 +1,7 @@
 # Tests to simulate multivariate traits
 
-using PhyloNetworks, LinearAlgebra, Test
-import Random
+# using PhyloNetworks, LinearAlgebra, Test
+# import Random
 
 ## Get a network and make it ultrametric
 net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -97,6 +97,8 @@ Random.seed!(24452384); # fix the seed
 Σ = Σ * Σ' # needs to be positive definite
 pars = ParamsMultiBM(μ, Σ); # params of a MBD
 
+@test_logs show(devnull, pars)
+
 Σ_root = randn(trait_dim, trait_dim)
 Σ_root = Σ_root * Σ_root' / 10.0 # needs to be positive definite (and not too big to reduce variance in test)
 pars.varRoot = Σ_root
@@ -150,6 +152,7 @@ net = readTopology("(A:2.5,((B:1,#H1:0.5::0.4):1,(C:1,(D:0.5)#H1:0.5::0.6):1):0.
 ## Test construction function
 @test_throws ErrorException ShiftNet(net.edge[7], [1.0, 2.0],  net) # can't put a shift on hybrid branch
 @test_throws ErrorException ShiftNet(net.node[6], [1.0, 2.0],  net) # can't put a shift on hybrid branch
+@test_throws ErrorException ShiftNet([net.node[7], net.node[6]], [1.0 2.0], net) # dimensions don't match
 @test ShiftNet(net.edge[8], [1.0, 2.0],  net).shift ≈ ShiftNet([net.edge[8]], [1.0 2.0],  net).shift
 @test ShiftNet(net.edge[8], [1.0, 2.0],  net).shift ≈ ShiftNet(net.node[7], [1.0, 2.0],  net).shift
 @test ShiftNet(net.node[7], [1.0, 2.0],  net).shift ≈ ShiftNet([net.node[7]], [1.0 2.0],  net).shift
@@ -169,6 +172,7 @@ sh1 = ShiftNet(net.node[7], [1.0, 2.0],  net)*ShiftNet(net.node[9], [3.0, -1.5],
 
 ## Hybrid shifts
 @test shiftHybrid([4.5 2.0], net).shift ≈ ShiftNet(net.edge[6], [4.5, 2.0], net).shift
+@test_throws ErrorException shiftHybrid([4.5 2.0; 3.0 5.0], net) # dimension mismatch
 
 ## Distributions
 

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -5,7 +5,7 @@ net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H
 P = 3
 
 
-@testset "Simulate function against fixed values" begin
+@testset "Simulate data and check means and dimensions" begin
 
 ## Simulate a MBD
 Random.seed!(17920921); # fix the seed
@@ -27,7 +27,6 @@ traitsNodes = sim[:InternalNodes];
 @test size(traitsNodes) == (P, net.numNodes - net.numTaxa)
 
 expectations = sim[:All, :Exp]
-@show size(expectations)
 
 # Check means (no shifts)
 max_diff = maximum(expectations - μ * ones(net.numNodes)')

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -1,0 +1,80 @@
+# Tests to simulate multivariate traits
+
+## Get a network and make it ultrametric
+net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");
+P = 3
+
+
+@testset "Simulate function against fixed values" begin
+
+## Simulate a MBD
+Random.seed!(17920921); # fix the seed
+μ = randn(P)
+Σ = randn(P, P)
+Σ = Σ * Σ' # needs to be positive definite
+pars = ParamsMultiBM(μ, Σ); # params of a MBD
+@test_logs show(devnull, pars)
+
+sim = simulate(net, pars); # simulate according to a BM
+@test_logs show(devnull, sim)
+
+# Extract simulated values
+traitsTips = sim[:Tips];
+traitsNodes = sim[:InternalNodes];
+
+# Check dimensions
+@test size(traitsTips) == (P, net.numTaxa)
+@test size(traitsNodes) == (P, net.numNodes - net.numTaxa)
+
+expectations = sim[:All, :Exp]
+@show size(expectations)
+
+# Check means (no shifts)
+max_diff = maximum(expectations - μ * ones(net.numNodes)')
+@test max_diff ≈ 0.0 atol=1e-10
+
+end
+
+###############################################################################
+## Test of distibution
+###############################################################################
+@testset "Simulate test distribution" begin
+
+## Generate some values
+Random.seed!(18480224); # fix the seed
+μ = randn(P)
+Σ = randn(P, P)
+Σ = Σ * Σ' # needs to be positive definite
+pars = ParamsMultiBM(μ, Σ); # params of a MBD
+
+N = 50000
+S = length(tipLabels(net));
+μ_sim = zeros(P, S)
+Σ_sim = zeros(P * S, P * S)
+for i = 1:N
+    tips = simulate(net, pars)[:Tips]
+    μ_sim .+= tips
+    v_sim = vec(tips)
+    Σ_sim += v_sim * v_sim'
+end
+
+μ_sim ./= N
+Σ_sim ./= N
+Σ_sim = Σ_sim - vec(μ_sim) * vec(μ_sim)'
+
+## Check means
+
+μ_true = μ * ones(S)'
+
+μ_max = maximum(abs.(μ_true - μ_sim))
+@test μ_max < 1e-1
+
+## Check covariance
+
+Ψ = Matrix(vcv(net))
+Σ_true = kron(Ψ, Σ)
+Σ_max = maximum(abs.(Σ_true - Σ_sim))
+@test Σ_max < 2e-1
+
+
+end

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -1,5 +1,8 @@
 # Tests to simulate multivariate traits
 
+# using PhyloNetworks, LinearAlgebra, Test
+# import Random
+
 ## Get a network and make it ultrametric
 net = readTopology("(((Ag:5,(#H1:1::0.056,((Ak:2,(E:1,#H2:1::0.004):1):1,(M:2)#H2:1::0.996):1):1):1,(((((Az:1,Ag2:1):1,As:2):1)#H1:1::0.944,Ap:4):1,Ar:5):1):1,(P:4,20:4):3,165:7);");
 trait_dim = 3
@@ -35,9 +38,9 @@ max_diff = maximum(expectations - μ * ones(net.numNodes)')
 end
 
 ###############################################################################
-## Test of distibution
+## Test of distibution (fixed root)
 ###############################################################################
-@testset "Simulate test distribution" begin
+@testset "Simulate test distribution (fixed root)" begin
 
 ## Generate some values
 Random.seed!(18480224); # fix the seed
@@ -73,6 +76,56 @@ end
 Ψ = Matrix(vcv(net))
 Σ_true = kron(Ψ, Σ)
 Σ_max = maximum(abs.(Σ_true - Σ_sim))
+@test Σ_max < 2e-1
+
+
+end
+
+###############################################################################
+## Test of distibution (random root)
+###############################################################################
+@testset "Simulate test distribution (random root)" begin
+
+## Generate some values
+Random.seed!(24452384); # fix the seed
+μ = randn(trait_dim)
+Σ = randn(trait_dim, trait_dim)
+Σ = Σ * Σ' # needs to be positive definite
+pars = ParamsMultiBM(μ, Σ); # params of a MBD
+
+Σ_root = randn(trait_dim, trait_dim)
+Σ_root = Σ_root * Σ_root' / 10.0 # needs to be positive definite (and not too big to reduce variance in test)
+pars.varRoot = Σ_root
+pars.randomRoot = true
+
+N = 50000
+S = length(tipLabels(net));
+μ_sim = zeros(trait_dim, S)
+Σ_sim = zeros(trait_dim * S, trait_dim * S)
+for i = 1:N
+    tips = simulate(net, pars)[:Tips]
+    μ_sim .+= tips
+    v_sim = vec(tips)
+    Σ_sim += v_sim * v_sim'
+end
+
+μ_sim ./= N
+Σ_sim ./= N
+Σ_sim = Σ_sim - vec(μ_sim) * vec(μ_sim)'
+
+## Check means
+
+μ_true = μ * ones(S)'
+
+μ_max = maximum(abs.(μ_true - μ_sim))
+@test μ_max < 1e-1
+
+## Check covariance
+
+Ψ = Matrix(vcv(net))
+Σ_true = kron(Ψ, Σ) + kron(ones(S, S), pars.varRoot)
+Σ_max = maximum(abs.(Σ_true - Σ_sim))
+@show Σ_max
 @test Σ_max < 2e-1
 
 

--- a/test/test_simulate_mbd.jl
+++ b/test/test_simulate_mbd.jl
@@ -156,6 +156,7 @@ net = readTopology("(A:2.5,((B:1,#H1:0.5::0.4):1,(C:1,(D:0.5)#H1:0.5::0.6):1):0.
 
 ## Concatenate function
 sh1 = ShiftNet(net.node[7], [1.0, 2.0],  net)*ShiftNet(net.node[9], [3.0, -1.5],  net)
+@test_logs show(devnull, sh1)
 @test sh1.shift ≈ ShiftNet([net.node[7], net.node[9]], [1.0 2.0; 3.0 -1.5],  net).shift
 @test_throws ErrorException sh1*ShiftNet(net.edge[7], [4.0, 3.5],  net) # can't concatenate if the two affect the same edges
 @test sh1.shift ≈ (sh1*ShiftNet([net.node[7]], [1.0 2.0],  net)).shift


### PR DESCRIPTION
Major changes (from last pull request):
- Fixing bug (and adding test) with random root in `ParamsMultiBM`.
- Adding shift for `ParamsMultiBM
- jldoctests for `simulate()` and `ParamsMultiBM` 
- Memory efficient calculations in `ParamsMultiBM`

The only changes that may affect users is that `getShiftValue()` now returns a 2-d array instead of a 1-d array. I had to make a small change to `test_simulate.jl` to accommodate this, but otherwise everything is the same. Note that for a 1-d process the array still only has one column, it's just an `Array{Float64, 2}` instead of an `Array{Float64, 1}`. Let me know if that's a problem and I'll figure out how to keep the original behavior.