### PR TITLE
hardwiredClusterDistance fix

### DIFF
--- a/src/compareNetworks.jl
+++ b/src/compareNetworks.jl
@@ -682,8 +682,7 @@ If rooted=false, the trees are considered unrooted.
 If rooted is false and one of the phylogenies is not a tree (1+ reticulations),
 then all degree-2 nodes are removed before comparing the hardwired clusters,
 and the minimum distance is returned over all possible ways to root the
-networks. When trying to root a network at a leaf, the root is placed
-along the external branch to the leaf (creating a single degree-2 node).
+networks at internal nodes.
 """
 function hardwiredClusterDistance(net1::HybridNetwork, net2::HybridNetwork, rooted::Bool)
     bothtrees = (net1.numHybrids == 0 && net2.numHybrids == 0)
@@ -703,7 +702,7 @@ function hardwiredClusterDistance(net1::HybridNetwork, net2::HybridNetwork, root
     end
     dis = 0
     n2ci = collect(1:size(M2, 1)) # cluster indices
-    for i1=1:size(M1,1)
+    for i1 in 1:size(M1,1)
         found = false
         m1 = 1 .- M1[i1,2:end] # going to the end: i.e. we want to match a tree edge with a tree edge
                                 # and hybrid edge with hybrid edge
@@ -735,9 +734,10 @@ rooted distance, over all root positions that are compatible with the direction
 of hybrid edges.
 Called by [`hardwiredClusterDistance`](@ref).
 
-Since rooting the network at a leaf creates a root node of degree 2 and may
-require to delete the previous node, if it was of degree 2, all degree-2 nodes
+To avoid repeating identical clusters, all degree-2 nodes
 are deleted before starting the comparison.
+Since rooting the network at a leaf creates a root node of degree 2 and
+an extra cluster, leaves are excluded from possible rooting positions.
 """
 function hardwiredClusterDistance_unrooted(net1::HybridNetwork, net2::HybridNetwork)
     return hardwiredClusterDistance_unrooted!(deepcopy(net1), deepcopy(net2))
@@ -750,7 +750,10 @@ function hardwiredClusterDistance_unrooted!(net1::HybridNetwork, net2::HybridNet
     removedegree2nodes!(net1) # because re-rooting would remove them in an
     removedegree2nodes!(net2) # unpredictable order
     # find all permissible positions for the root
-    net1roots = [n.number for n in net1.node]
+    net1roots = [n.number for n in net1.node if !n.leaf]
+    #= disallow the root at a leaf: adding a degree-2 node adds a cluster
+       that could be artificially matched to a cluster from a degree-3 node
+       sister to a hybrid edge, when a the leaf edge is the donor. =#
     for i in length(net1roots):-1:1 # reverse order, to delete some of them
         try
             rootatnode!(net1, net1roots[i]; verbose=false)
@@ -761,7 +764,7 @@ function hardwiredClusterDistance_unrooted!(net1::HybridNetwork, net2::HybridNet
             deleteat!(net1roots, i)
         end
     end
-    net2roots = [n.number for n in net2.node]
+    net2roots = [n.number for n in net2.node if !n.leaf]
     for i in length(net2roots):-1:1
         try
             rootatnode!(net2, net2roots[i]; verbose=false)

--- a/src/compareNetworks.jl
+++ b/src/compareNetworks.jl
@@ -720,7 +720,6 @@ function hardwiredClusterDistance(net1::HybridNetwork, net2::HybridNetwork, root
         end
     end # (size(M1)[1] - dis) edges have been found in net2, dis edges have not.
     # so size(M2)[1] - (size(M1)[1] - dis) edges in net2 are not in net1.
-    @info "at end of hardwiredClusterDistance, dis = $dis, diff = $(size(M2)[1] - size(M1)[1])"
     dis + dis + size(M2)[1] - size(M1)[1]
 end
 
@@ -774,22 +773,19 @@ function hardwiredClusterDistance_unrooted!(net1::HybridNetwork, net2::HybridNet
         end
     end
     bestdissimilarity = typemax(Int)
-    bestn1 = missing
-    bestn2 = missing
+    bestns = missing
     for n1 in net1roots
         rootatnode!(net1, n1; verbose=false)
         for n2 in net2roots
             rootatnode!(net2, n2; verbose=false)
             diss = hardwiredClusterDistance(net1, net2, true) # rooted = true now
-            @info "After calling hwcd, diss = $diss"
             if diss < bestdissimilarity
-                bestn1 = n1
-                bestn2 = n2
+                bestns = (n1, n2)
                 bestdissimilarity = diss
             end
         end
     end
-    @show bestn1, bestn2
+    # @info "best root nodes: $bestns"
     # warning: original roots (and edge directions) NOT restored
     return bestdissimilarity
 end

--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -108,7 +108,7 @@ tree2 = majorTree(net2);        tree3 = majorTree(net3);
 deleteleaf!(tree2,"Xhellerii"); deleteleaf!(tree3,"Xhellerii");
 deleteleaf!(tree2,"Xsignum");   deleteleaf!(tree3,"Xsignum");
 hardwiredClusterDistance(tree2, tree3, false) == 0 || error("HWD not 0, major tree - 2 taxa");
-hardwiredClusterDistance(tree2, tree3, true) == 20 || error("rooted RF dist not 20");
+@test hardwiredClusterDistance(tree2, tree3, true) == 21
 rootatnode!(tree3,"Xmaculatus");
 hardwiredClusterDistance(tree2, tree3, true) == 15 || error("rooted RF dist not 15");
 rootatnode!(tree2,"Xgordoni");
@@ -129,7 +129,7 @@ net3  = readTopology(cui3str);
 @test hardwiredClusterDistance(net2, net3, true) == 3
 @test_logs rootatnode!(net3,"Xmayae");
 @test hardwiredClusterDistance(net2, net3, true) == 4
-@test hardwiredClusterDistance(net2, net3, false) == 3
+@test hardwiredClusterDistance(net2, net3, false) == 4
 @test_logs deleteleaf!(net3,"Xmayae"; unroot=true);    #plot(net3);
 @test net3.numHybrids == 2
 # using simplify=false in deleteleaf!
@@ -355,8 +355,8 @@ rootatnode!(trunet, -8)
 h0est = readTopology("(((2:0.01,1:0.01):0.033,(3:0.0154,4:0.0149):0.0186):0.0113,6:0.0742,5:0.0465);")
 truenet = readTopology("((((1,2),((3,4))#H1),(#H1,5)),6);")
 h1est = readTopology("(5:0.0,6:0.0,(((2:0.0)#H1:0.0::0.95,1:0.0):0.0,((4:0.0,3:0.0):0.0,#H1:0.0::0.05):0.0):0.0);")
-@test hardwiredClusterDistance(h0est, truenet, false) == 1
-@test hardwiredClusterDistance(truenet, h0est, false) == 1
+@test hardwiredClusterDistance(h0est, truenet, false) == 2
+@test hardwiredClusterDistance(truenet, h0est, false) == 2
 @test hardwiredClusterDistance(h1est, truenet, false) == 4
 @test hardwiredClusterDistance(truenet, h1est, false) == 4
 

--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -350,7 +350,7 @@ estminor = minorTreeAt(estnet, 1); # (5:1.0,(3:1.0,4:1.0):1.069,(6:1.0,(1:1.0,2:
 # so the hybrid edge was estimated correctly!!
 rootatnode!(trunet, -8)
 @test hardwiredClusterDistance(estnet, trunet, true) == 3
-@test_broken hardwiredClusterDistance(estnet, trunet, false) == 0
+@test hardwiredClusterDistance(estnet, trunet, false) == 0
 
 net5 = readTopology("(A,((B,#H1:::0.2),(((C,(E)#H2:::0.7),(#H2:::0.3,F)),(D)#H1:::0.8)));");
 tree = displayedTrees(net5, 0.0);
@@ -437,16 +437,13 @@ end # of testset: displayedTrees, hardwiredClusters, hardwiredClusterDistance, d
 @testset "testing hardwiredClusterDistance_unrooted" begin
 h0est = readTopology("(((2:0.01,1:0.01):0.033,(3:0.0154,4:0.0149):0.0186):0.0113,6:0.0742,5:0.0465);")
 truenet = readTopology("((((1,2),((3,4))#H1),(#H1,5)),6);")
+h1est = readTopology("(5:0.0,6:0.0,(((2:0.0)#H1:0.0::0.95,1:0.0):0.0,((4:0.0,3:0.0):0.0,#H1:0.0::0.05):0.0):0.0);")
+
 @test PhyloNetworks.hardwiredClusterDistance_unrooted(h0est, truenet) == 1
 @test PhyloNetworks.hardwiredClusterDistance_unrooted(truenet, h0est) == 1
 
-h1est = readTopology("(5:0.0,6:0.0,(((2:0.0)#H1:0.0::0.95,1:0.0):0.0,((4:0.0,3:0.0):0.0,#H1:0.0::0.05):0.0):0.0);")
-@test PhyloNetworks.hardwiredClusterDistance_unrooted(h1est, truenet) == 4
-@test PhyloNetworks.hardwiredClusterDistance_unrooted(truenet, h1est) == 4
-rootatnode!(h1est, "5")
-rootatnode!(truenet, "5")
-@test hardwiredClusterDistance(truenet, h1est, true) == 4
-@test hardwiredClusterDistance(h1est, truenet, true) == 4
+@test PhyloNetworks.hardwiredClusterDistance_unrooted(h1est, truenet) == 3
+@test PhyloNetworks.hardwiredClusterDistance_unrooted(truenet, h1est) == 3
 end
 
 @testset "testing hardwiredCluster! on single nodes" begin

--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -434,6 +434,21 @@ end
 
 end # of testset: displayedTrees, hardwiredClusters, hardwiredClusterDistance, displayedNetworkAt!
 
+@testset "testing hardwiredClusterDistance_unrooted" begin
+h0est = readTopology("(((2:0.01,1:0.01):0.033,(3:0.0154,4:0.0149):0.0186):0.0113,6:0.0742,5:0.0465);")
+truenet = readTopology("((((1,2),((3,4))#H1),(#H1,5)),6);")
+@test PhyloNetworks.hardwiredClusterDistance_unrooted(h0est, truenet) == 1
+@test PhyloNetworks.hardwiredClusterDistance_unrooted(truenet, h0est) == 1
+
+h1est = readTopology("(5:0.0,6:0.0,(((2:0.0)#H1:0.0::0.95,1:0.0):0.0,((4:0.0,3:0.0):0.0,#H1:0.0::0.05):0.0):0.0);")
+@test PhyloNetworks.hardwiredClusterDistance_unrooted(h1est, truenet) == 4
+@test PhyloNetworks.hardwiredClusterDistance_unrooted(truenet, h1est) == 4
+rootatnode!(h1est, "5")
+rootatnode!(truenet, "5")
+@test hardwiredClusterDistance(truenet, h1est, true) == 4
+@test hardwiredClusterDistance(h1est, truenet, true) == 4
+end
+
 @testset "testing hardwiredCluster! on single nodes" begin
 
 net5 = "(A,((B,#H1),(((C,(E)#H2),(#H2,F)),(D)#H1)));" |> readTopology |> directEdges! ;

--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -350,7 +350,15 @@ estminor = minorTreeAt(estnet, 1); # (5:1.0,(3:1.0,4:1.0):1.069,(6:1.0,(1:1.0,2:
 # so the hybrid edge was estimated correctly!!
 rootatnode!(trunet, -8)
 @test hardwiredClusterDistance(estnet, trunet, true) == 3
+# next: testing hardwiredClusterDistance_unrooted, via the option rooted=false
 @test hardwiredClusterDistance(estnet, trunet, false) == 0
+h0est = readTopology("(((2:0.01,1:0.01):0.033,(3:0.0154,4:0.0149):0.0186):0.0113,6:0.0742,5:0.0465);")
+truenet = readTopology("((((1,2),((3,4))#H1),(#H1,5)),6);")
+h1est = readTopology("(5:0.0,6:0.0,(((2:0.0)#H1:0.0::0.95,1:0.0):0.0,((4:0.0,3:0.0):0.0,#H1:0.0::0.05):0.0):0.0);")
+@test hardwiredClusterDistance(h0est, truenet, false) == 1
+@test hardwiredClusterDistance(truenet, h0est, false) == 1
+@test hardwiredClusterDistance(h1est, truenet, false) == 4
+@test hardwiredClusterDistance(truenet, h1est, false) == 4
 
 net5 = readTopology("(A,((B,#H1:::0.2),(((C,(E)#H2:::0.7),(#H2:::0.3,F)),(D)#H1:::0.8)));");
 tree = displayedTrees(net5, 0.0);
@@ -433,18 +441,6 @@ hardwiredClusterDistance(net51,net52,true) == 4 ||
 end
 
 end # of testset: displayedTrees, hardwiredClusters, hardwiredClusterDistance, displayedNetworkAt!
-
-@testset "testing hardwiredClusterDistance_unrooted" begin
-h0est = readTopology("(((2:0.01,1:0.01):0.033,(3:0.0154,4:0.0149):0.0186):0.0113,6:0.0742,5:0.0465);")
-truenet = readTopology("((((1,2),((3,4))#H1),(#H1,5)),6);")
-h1est = readTopology("(5:0.0,6:0.0,(((2:0.0)#H1:0.0::0.95,1:0.0):0.0,((4:0.0,3:0.0):0.0,#H1:0.0::0.05):0.0):0.0);")
-
-@test PhyloNetworks.hardwiredClusterDistance_unrooted(h0est, truenet) == 1
-@test PhyloNetworks.hardwiredClusterDistance_unrooted(truenet, h0est) == 1
-
-@test PhyloNetworks.hardwiredClusterDistance_unrooted(h1est, truenet) == 3
-@test PhyloNetworks.hardwiredClusterDistance_unrooted(truenet, h1est) == 3
-end
 
 @testset "testing hardwiredCluster! on single nodes" begin
 


### PR DESCRIPTION
Fixes case where an edge in one network could be counted twice. This led to a different hardwired cluster distance depending on which network is called first. Adds testing for this case.

Remaining Questions:
- An unexpected difference between `hardwiredClusterDistance` and `hardwiredClusterDistance_unrooted`: The first gives a distance of 4 (after rooting on leaf at taxa "5"), but the second gives a distance of 3. The second function roots the true network in a new place (at node number -8). I've attached plots of the two networks, rooted at this new root found by hardwiredClusterDistance_unrooted (node number -8 and 1). The code to replicate this can be found [here](https://github.com/crsl4/PhyloNetworks.jl/blob/6cc537630368bedd6ff2ee48fa05b7ed0ab09e7d/test/test_compareNetworks.jl#L437). I've changed the test to reflect this new rooting.

- The new version gives HWCD = 1 between the true net and h0 in test_compareNetworks.jl at line 353. I thought it should be two, but perhaps I'm calculating incorrectly.

- After the new changes, we get an unexpected pass in test_compareNetworks.jl at line 353. I've replaced`@test_broken` with `@test`.