### PR TITLE
Fix bug in backward likelihood calculation

### DIFF
--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -1437,12 +1437,10 @@ function optimizelength_LiNC!(obj::SSM, focusedge::Edge,
         #@show loglik + adjustment
         return loglik
     end
-    #=
     oldlik = objective([focusedge.length], [0.0]) + adjustment
     oldlik ≈ obj.loglik || @warn "oldlik $oldlik != stored lik $(obj.loglik): starting NNI?"
     # obj.loglik outdated at the start of an NNI move:
     # it is for the older, not the newly proposed topology
-    =#
     optBL = lcache.opt
     NLopt.max_objective!(optBL, objective)
     # @info "BL: edge $(focusedge.number)"
@@ -1703,19 +1701,17 @@ function optimizegamma_LiNC!(obj::SSM, focusedge::Edge,
     # derivative of loglik at γ=0
     llg0 = wsum(ulik)
     inside01 = true
-    if llg0 < 0
+    if llg0 <= 0.0 # if llg0 = 0, something fishy is happening or data has no variation
         γ = 0.0
         inside01 = false
         ll = wsum((visib ? log.(clikp) : log.(clikp .+ clikn)))
         @debug "γ = 0 best, skip Newton-Raphson"
-    elseif llg0 == 0.0 # if llg0 = 0, something fishy is happening.
-        @error("llg0 is $llg0 and optimization is proceeding. Something is wrong.")
     else # at γ=1
         if visib
              ulik .= (clike .- clikp) ./ clike
         else ulik .= (clike .- clikp) ./ (clike .+ clikn); end
         llg1 = wsum(ulik)
-        if llg1 > 0
+        if llg1 >= 0.0 # if llg1 = 0.0, data has no variation
             γ = 1.0
             inside01 = false
             ll = wsum((visib ? log.(clike) : log.(clike .+ clikn)))

--- a/src/phyLiNCoptimization.jl
+++ b/src/phyLiNCoptimization.jl
@@ -1437,10 +1437,12 @@ function optimizelength_LiNC!(obj::SSM, focusedge::Edge,
         #@show loglik + adjustment
         return loglik
     end
+    #=
     oldlik = objective([focusedge.length], [0.0]) + adjustment
     oldlik ≈ obj.loglik || @warn "oldlik $oldlik != stored lik $(obj.loglik): starting NNI?"
     # obj.loglik outdated at the start of an NNI move:
     # it is for the older, not the newly proposed topology
+    =#
     optBL = lcache.opt
     NLopt.max_objective!(optBL, objective)
     # @info "BL: edge $(focusedge.number)"

--- a/src/traitsLikDiscrete.jl
+++ b/src/traitsLikDiscrete.jl
@@ -1074,7 +1074,7 @@ function discrete_backwardlikelihood_trait!(obj::SSM, t::Integer, ri::Integer)
     k = nstates(obj.model)
     fill!(backwardlik, 0.0) # re-initialize for each trait, each iteration
     bkwtmp = Vector{Float64}(undef, k) # to hold bkw lik without parent edge transition
-    if typeof(obj.model) == NASM
+    if typeof(obj.model) <: NASM
         logprior = log.(stationary(obj.model))
     else #trait models
         logprior = [-log(k) for i in 1:k] # uniform prior at root


### PR DESCRIPTION
- fixes a bug in the backward likelihood calculation that prevented the correct stationary distribution from being used. This bug, now resolved, led to an incorrect likelihood calculation within optimizelength.
- handles the case of data without variation where llg0 and llg1 could equal 0.0 during gamma optimization