### PR TITLE
fliphybrid root fix, nnidistance functions, PhyLiNC fixed network optimization

### DIFF
--- a/src/compareNetworks.jl
+++ b/src/compareNetworks.jl
@@ -692,7 +692,7 @@ networks at internal nodes.
 function hardwiredClusterDistance(net1::HybridNetwork, net2::HybridNetwork, rooted::Bool)
     bothtrees = (net1.numHybrids == 0 && net2.numHybrids == 0)
     rooted || bothtrees ||
-        return hardwiredClusterDistance_unrooted(net1, net2) # tries all roots, but removes degree-2 nodes
+        return hardwiredClusterDistance_semirooted(net1, net2) # tries all roots, but removes degree-2 nodes
     taxa = sort!(String[net1.leaf[i].name for i in 1:net1.numTaxa])
     length(setdiff(taxa, String[net2.leaf[i].name for i in 1:net2.numTaxa])) == 0 ||
         error("net1 and net2 do not share the same taxon set. Please prune networks first.")
@@ -730,10 +730,10 @@ end
 
 
 """
-    hardwiredClusterDistance_unrooted(net1::HybridNetwork, net2::HybridNetwork)
+    hardwiredClusterDistance_semirooted(net1::HybridNetwork, net2::HybridNetwork)
 
-Miminum hardwired cluster dissimilarity between the two networks, considered as
-unrooted (or semi-directed). This dissimilarity is defined as the minimum
+Miminum hardwired cluster dissimilarity between the two networks when considered
+semi-rooted (aka semi-directed). This dissimilarity is defined as the minimum
 rooted distance, over all root positions that are compatible with the direction
 of hybrid edges.
 Called by [`hardwiredClusterDistance`](@ref).
@@ -743,10 +743,10 @@ are deleted before starting the comparison.
 Since rooting the network at a leaf creates a root node of degree 2 and
 an extra cluster, leaves are excluded from possible rooting positions.
 """
-function hardwiredClusterDistance_unrooted(net1::HybridNetwork, net2::HybridNetwork)
-    return hardwiredClusterDistance_unrooted!(deepcopy(net1), deepcopy(net2))
+function hardwiredClusterDistance_semirooted(net1::HybridNetwork, net2::HybridNetwork)
+    return hardwiredClusterDistance_semirooted!(deepcopy(net1), deepcopy(net2))
 end
-function hardwiredClusterDistance_unrooted!(net1::HybridNetwork, net2::HybridNetwork)
+function hardwiredClusterDistance_semirooted!(net1::HybridNetwork, net2::HybridNetwork)
     #= fixit: inefficient function, because r1 * r2 "M" matrices of
       hardwiredClusters() are calculated, where ri = # root positions in neti.
       Rewrite to calculate only r1 + r2 M's.
@@ -793,4 +793,58 @@ function hardwiredClusterDistance_unrooted!(net1::HybridNetwork, net2::HybridNet
     # @info "best root nodes: $bestns"
     # warning: original roots (and edge directions) NOT restored
     return bestdissimilarity
+end
+
+"""
+    nnidistance(startingnet::HybridNetwork, truenet::HybridNetwork,
+                outgroup::String, nohybridladder::Bool, no3cycle::Bool,
+                maxmoves=2::Int,
+                constraints=TopologyConstraint[]::Vector{TopologyConstraint})
+
+Return the minimum number of NNI moves to get from `startingnet` to `truenet`.
+If no moves needed, return 0. If net cannot be found in `maxmoves` NNI moves,
+return Inf. Networks must have the same taxa. If not, will return an error.
+
+To avoid a very long run, choose a small `maxmoves` to start. Because the
+number of neighbors increases exponentially, this function is time-consuming
+even with small `maxmoves`. After nmoves, size of the neighbor set is
+(startingnet's immediate neighbors)^nmoves.
+(In other words, this problem is fixed-parameter tractable with `maxmoves` fixed.)
+e.g. If `startingnet` has 10 immediate neighbors, then after 3 moves, it will have
+~1000 neighbors.
+"""
+function nnidistance(startingnet::HybridNetwork, truenet::HybridNetwork,
+                     outgroup::String, nohybridladder::Bool, no3cycle::Bool,
+                     maxmoves=2::Int,
+                     constraints=TopologyConstraint[]::Vector{TopologyConstraint})
+    if sort([l.name for l in truenet.leaf]) != sort([l.name for l in startingnet.leaf])
+        error("Networks have different taxa. Cannot compute an nni distance between networks with different taxa.")
+    end
+    rootatnode!(startingnet, outgroup) # confirm startingnet is rooted at outgroup
+    removedegree2nodes!(startingnet) # rooting adds a node of degree two. This removes it.
+    nmoves = 0
+    if hardwiredClusterDistance(startingnet, truenet, true) == 0
+        @debug "After rerooting, startingnet and truenet match. No NNI moves were needed."
+        return nmoves
+    end
+    startingnets = [writeTopology(startingnet)]
+    while nmoves < maxmoves
+        nmoves += 1
+        allneighbors = String[] # reset to zero to create new set of neighbors
+        for s in 1:length(startingnets)
+            snet = readTopology(startingnets[s])
+            neighbors = uniqueneighbornets(snet, nohybridladder, no3cycle, constraints)
+            for n in 1:length(neighbors) # see if we found truenet
+                if hardwiredClusterDistance(readTopology(neighbors[n]), truenet, true) == 0
+                    @debug "After $nmoves move(s), startingnet was transformed into truenet with NNIs."
+                    return nmoves
+                end
+            end
+            allneighbors = vcat(allneighbors, neighbors)
+        end
+        # use these neighbors as the next startingnets
+        startingnets = allneighbors
+    end
+    @debug "After $nmoves move(s), startingnet could not be transformed into truenet using NNIs."
+    return Inf
 end

--- a/src/moves_semidirected.jl
+++ b/src/moves_semidirected.jl
@@ -370,23 +370,24 @@ end
     nni!(net::HybridNetwork, uv::Edge, nummove::UInt8,
          nohybridladder::Bool, no3cycle::Bool)
 
-Modify `net` with a nearest neighbor interchange (NNI) around edge `uv`.
-Return the information necessary to undo the NNI, or `nothing` if the move
-was not successful (such as if the resulting graph was not acyclic (not a DAG) or if
-the focus edge is adjacent to a polytomy). If the move fails, the network is not
-modified.
-`nummove` specifies which of the available NNIs is performed.
+Modify `net` with a semi-directed nearest neighbor interchange (sNNI) around
+edge `uv`. Return the information necessary to undo the sNNI, or `nothing` if \
+the move was not successful (such as if the resulting graph was not acyclic
+(not a DAG) or if the focus edge is adjacent to a polytomy). If the move fails,
+the network is not modified.
 
-rooted-NNI options according to Gambette et al. (2017), fig. 8:
+`nummove` specifies which of the available sNNIs is performed.
+
+Expanded from the rooted-NNI (rNNI) options in Gambette et al. (2017), fig. 8:
 * BB: 2 moves, both to BB, if directed edges. 8 moves if undirected.
 * RR: 2 moves, both to RR.
 * BR: 3 moves, 1 RB & 2 BRs, if directed. 6 moves if e is undirected.
 * RB: 4 moves, all 4 BRs.
-The extra options are due to assuming a semi-directed network, whereas
-Gambette et al (2017) describe options for rooted networks.
-On a semi-directed network, there might be a choice of how to direct
-the edges that may contain the root, e.g. choice of e=uv versus vu, and
-choice of labelling adjacent nodes as α/β (BB), or as α/γ (BR).
+Our extra sNNI options come from assuming a semi-directed network, in
+constrast to Gambette et al (2017)'s rooted networks. On a semi-directed network,
+there may be a choice in how to direct the edges that may contain the root:
+e.g. choice of e=uv versus vu and choice of labelling adjacent nodes as
+α/β (BB) or as α/γ (BR).
 
 `nohybridladder` = true prevents moves that would create a hybrid ladder in
 the network, that is, 2 consecutive hybrid nodes (one parent of the other).

--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -352,7 +352,7 @@ estminor = minorTreeAt(estnet, 1); # (5:1.0,(3:1.0,4:1.0):1.069,(6:1.0,(1:1.0,2:
 # so the hybrid edge was estimated correctly!!
 rootatnode!(trunet, -8)
 @test hardwiredClusterDistance(estnet, trunet, true) == 3
-# next: testing hardwiredClusterDistance_unrooted, via the option rooted=false
+# next: testing hardwiredClusterDistance_semirooted, via the option rooted=false
 @test hardwiredClusterDistance(estnet, trunet, false) == 0
 h0est = readTopology("(((2:0.01,1:0.01):0.033,(3:0.0154,4:0.0149):0.0186):0.0113,6:0.0742,5:0.0465);")
 truenet = readTopology("((((1,2),((3,4))#H1),(#H1,5)),6);")
@@ -468,5 +468,16 @@ for i = 1:16
   @test hardwiredCluster(net5.edge[i], taxa) == m[:,i]
 end
 end # of testset, hardwiredCluster! on single nodes
+
+@testset "nni distance" begin
+startingnet = readTopology("(((1:0.009221630571539522,2:0.01090284156388857):0.03072521643460218,(3:1.0e-8,(4:0.0)#H1:0.01133912873252381::0.7292558128341733):0.030320601757657505):0.013615526953203836,6:0.07418479480620778,(5:0.016527926411687346,#H1:1.0000000050247593e-8::0.2707441871658267):0.026214884034880433);")
+truenet = readTopology("(((1:0.013635011856564799,2:0.013337412436279021):0.02379142358426221,((3:0.014458424150016028,4:0.015899483647102967):0.0)#H1:0.01602497696107314::0.7876602143873201):0.01491008237330521,(#H1:0.014834901504447811::0.2123397856126799,5:0.005527884554698987):0.055340371373774774,6:0.0620387315019168);")
+dist2net = readTopology("(((1:0.009221630571539522,2:0.01090284156388857):0.03072521643460218,(3:1.0e-8,(4:0.0)#H1:0.01133912873252381::0.7292558128341733):0.030320601757657505):0.013615526953203836,(6:0.07418479480620778,#H1:1.0000000050247593e-8::0.2707441871658267):0.026214884034880433,5:0.016527926411687346);")
+@test PhyloNetworks.nnidistance(startingnet, truenet, "6", true, true, 1) == 1
+@test PhyloNetworks.nnidistance(startingnet, truenet, "6", false, false, 1) == 1
+@test PhyloNetworks.nnidistance(truenet, truenet, "6", true, true, 1) == 0
+@test PhyloNetworks.nnidistance(dist2net, truenet, "6", true, true, 2) == 2
+@test PhyloNetworks.nnidistance(dist2net, truenet, "6", false, false, 1) == Inf
+end # nni distance
 
 end

--- a/test/test_moves_semidirected.jl
+++ b/test/test_moves_semidirected.jl
@@ -581,3 +581,12 @@ net_W = readTopology("(C:0.0262,(B:0.0)#H2:0.03::0.9756,(((D:0.1,A:0.1274):0.0)#
 @test isnothing(PhyloNetworks.fliphybrid!(net_W, true, true)) # all minor edge flips create a hybridladder
 @test net_W.hybrid[1].number == 3 # unchanged
 end
+
+@testset "neighbor networks" begin
+truenet = readTopology("(((1:0.013635011856564799,2:0.013337412436279021):0.02379142358426221,((3:0.014458424150016028,4:0.015899483647102967):0.0)#H1:0.01602497696107314::0.7876602143873201):0.01491008237330521,(#H1:0.014834901504447811::0.2123397856126799,5:0.005527884554698987):0.055340371373774774,6:0.0620387315019168);")
+startingnet = readTopology("(((1:0.009221630571539522,2:0.01090284156388857):0.03072521643460218,(3:1.0e-8,(4:0.0)#H1:0.01133912873252381::0.7292558128341733):0.030320601757657505):0.013615526953203836,6:0.07418479480620778,(5:0.016527926411687346,#H1:1.0000000050247593e-8::0.2707441871658267):0.026214884034880433);")
+@test length(PhyloNetworks.neighbornets(truenet, false, false)) == 40
+@test length(PhyloNetworks.uniqueneighbornets(truenet, true, true)) == 12
+@test length(PhyloNetworks.neighbornets(startingnet, true, true)) == 44
+@test length(PhyloNetworks.uniqueneighbornets(startingnet, false, true)) == 18
+end # testset "neighbor networks"

--- a/test/test_phyLiNCoptimization.jl
+++ b/test/test_phyLiNCoptimization.jl
@@ -272,7 +272,7 @@ obj = @test_nowarn PhyloNetworks.phyLiNC(net, fastasimple, :JC69, :G, 2; maxhybr
 net = readTopology("(((A:2.0,(B:1.0)#H1:0.1::0.9):1.5,(C:0.6,#H1:1.0::0.1):1.0):0.5,D:2.0);");
 obj = @test_nowarn PhyloNetworks.phyLiNC(net, fastasimple, :HKY85; maxhybrid=2,
                     no3cycle=true, nohybridladder=true, maxmoves=2, probST=1.0, # not enough moves to get back to a good topology
-                    nreject=1, nruns=1, filename="phyLiNC2", verbose=false, seed=0)
+                    nreject=1, nruns=1, filename="phyLiNC2", verbose=false, seed=5)
 @test obj.loglik > -24.21
 @test read("phyLiNC2.err", String) == ""
 @test startswith(read("phyLiNC2.log", String), "PhyLiNC network estimation starting")


### PR DESCRIPTION
- Fixes root placement after flipping hybrid in cases when the original hybrid node cannot be the root
- new functions `nnidistance` and `uniquennineighbors` to explore the sNNI distance and sNNI neighborhood of a network.
- new function `phyLiNC_fixednetwork` to optimize the parameters of a network without changing its topology.
- small docstring updates