### PR TITLE
newick parsing: handle negative edge lengths, comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://crsl4.github.io/PhyloNetworks.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://crsl4.github.io/PhyloNetworks.jl/dev)
 [![codecov](https://codecov.io/gh/crsl4/PhyloNetworks.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/crsl4/PhyloNetworks.jl)
-[![Coverage Status](https://coveralls.io/repos/crsl4/PhyloNetworks.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/crsl4/PhyloNetworks.jl?branch=master)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -72,4 +72,19 @@ with or without transgressive evolution after reticulations:
   SI on [dryad](http://dx.doi.org/10.5061/dryad.nt2g6)
   including a [tutorial for trait evolution](https://datadryad.org/bitstream/handle/10255/dryad.177752/xiphophorus_PCM_analysis.html?sequence=1)
   and a [tutorial for network calibration](https://datadryad.org/bitstream/handle/10255/dryad.177754/xiphophorus_networks_calibration.html?sequence=1).
-  
+
+Continuous traits, accounting for within-species variation:
+
+- Benjamin Teo, Jeffrey P. Rose, Paul Bastide & Cécile Ané (2022).
+  Accounting for intraspecific variation in continuous trait evolution
+  on a reticulate phylogeny.
+  [bioRxiv](https://doi.org/10.1101/2022.05.12.490814)
+
+For a discrete trait (influence of gene flow on the trait,
+ancestral state reconstruction, rates):
+
+- Karimi, Grover, Gallagher, Wendel, Ané & Baum (2020). Reticulate evolution
+  helps explain apparent homoplasy in floral biology and pollination in baobabs
+  (*Adansonia*; Bombacoideae; Malvaceae).
+  [Systematic Biology](https://academic.oup.com/sysbio/advance-article/doi/10.1093/sysbio/syz073/5613901?guestAccessKey=a32e7dd3-27fd-4a13-b171-7ff5d6da0e01),
+  69(3):462-478. doi: 10.1093/sysbio/syz073.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,15 +19,29 @@ and their use for trait evolution.
 
 ## References
 
+for the package:
 - Claudia Solís-Lemus, Paul Bastide and Cécile Ané (2017).
   PhyloNetworks: a package for phylogenetic networks.
   [Molecular Biology and Evolution](https://academic.oup.com/mbe/article/doi/10.1093/molbev/msx235/4103410/PhyloNetworks-a-package-for-phylogenetic-networks?guestAccessKey=230afceb-df28-4160-832d-aa7c73f86369)
   34(12):3292–3298.
   [doi:10.1093/molbev/msx235](https://doi.org/10.1093/molbev/msx235)
+
+for trait evolution:
+- Teo, Rose, Bastide & Ané (2022).
+  Accounting for intraspecific variation in continuous trait evolution
+  on a reticulate phylogeny.
+  [bioRxiv](https://doi.org/10.1101/2022.05.12.490814)
+- Karimi, Grover, Gallagher, Wendel, Ané & Baum (2020). Reticulate evolution
+  helps explain apparent homoplasy in floral biology and pollination in baobabs
+  (*Adansonia*; Bombacoideae; Malvaceae).
+  Systematic Biology, 69(3):462-478.
+  [doi:10.1093/sysbio/syz073](https://academic.oup.com/sysbio/advance-article/doi/10.1093/sysbio/syz073/5613901?guestAccessKey=a32e7dd3-27fd-4a13-b171-7ff5d6da0e01).
 - Bastide, Solís-Lemus, Kriebel, Sparks, Ané (2018).
   Phylogenetic Comparative Methods for Phylogenetic Networks with Reticulations.
   Systematic Biology, 67(5):800–820.
   [doi:10.1093/sysbio/syy033](https://doi.org/10.1093/sysbio/syy033).
+
+for network inference:
 - Claudia Solís-Lemus and Cécile Ané (2016).
   Inferring Phylogenetic Networks with Maximum Pseudolikelihood under Incomplete Lineage Sorting.
   [PLoS Genet](http://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005896)

--- a/test/test_relaxed_reading.jl
+++ b/test/test_relaxed_reading.jl
@@ -1,6 +1,6 @@
 @testset "test: newick parsing" begin
 global net
-@testset "readTopology White Symbol Tests" begin
+@testset "readTopology: spaces and comments" begin
     global n1, n2, n3
 	#Test newlines, spaces, tabs, and carriage returns
 	n1 = readTopology("(A,((B,#H1),(C,(D)#H1)));")
@@ -20,6 +20,18 @@ global net
 	resultant = readTopology("('H\tom\ro\nsa   p \n\n\n\n\n\n\n\ni\t\t\t\t\t\t\t\ten s   ', ((B,#H1),(C,(D)#H1)));")
 	expected = readTopology("('Homosapiens',((B,#H1),(C,(D)#H1)));")
 	@test writeTopology(resultant) == writeTopology(expected)
+
+    # nexus-style comments and negative edge or gamma values
+    n1 = (@test_logs (:error, r"expecting non-negative value") (:error, r"expecting non-negative value") readTopology("(E,((B)#H1[&com:1],((D:-1[&theta=2][&prob=0.3],C:[&length:4]1.2[&com 5])[&internalname=G],(#H1:::-0.1,A))))[&com=6];"))
+    @test writeTopology(n1) == "(E,((B)#H1:::1.0,((D:0.0,C:1.2),(#H1:::0.0,A))));"
+
+    # edge cases that should error
+    @test_throws Exception readTopology("(E,((B)#3,((D,C),(#3,A))));") # name not starting with letter
+    @test_logs (:warn,r"^Expected H") (:warn,r"^Expected H") readTopology("(E,((B)#P1,((D,C),(#P1,A))));")
+    @test_throws Exception readTopology("(E,((B)#H#h,((D,C),(#H#h,A))));") # 2 # sign in the name
+    @test_throws Exception readTopology("(E,((B)#H1,((D,C),((F)#H1,A))));") # both H1 internal
+    @test_throws Exception readTopology("(E,((B)#H1") # doesn't end with ;
+    @test_throws Exception readTopology(IOBuffer("E;")) # Expected beginning of tree with (
 end
 @testset "isMajor and gamma consistency" begin
 	net = readTopology("((((B)#H1)#H2,((D,C,#H2:::0.8),(#H1,A))));");


### PR DESCRIPTION
- negative edge lengths: fixes #176 by setting these lengths (and gamma values) to 0 and sending a log message of `:error` level
- allows for (and ignore) nexus-style comments within the extended newick, such as written by other software to add information about population size, posterior probability, mapping of a tip name to a population etc.