### PR TITLE
better handling of 2-cycle at the root

### DIFF
--- a/test/test_compareNetworks.jl
+++ b/test/test_compareNetworks.jl
@@ -81,7 +81,7 @@ end
 # example with simplify=false
 net0 = readTopology("((((((a:1)#H1:1::.9)#H2:1::.8)#H3:1::.7,#H3:0.5):1,#H2:1):1,(#H1:1,b:1):1,c:1);")
 net = deepcopy(net0)
-@test writeTopology(deletehybridedge!(net, net.edge[5]), round=true) == "(((a:1.0)#H1:2.0::0.9):1.0,(#H1:1.0::0.1,b:1.0):1.0,c:1.0);"
+@test writeTopology(deletehybridedge!(net, net.edge[5]), round=true) == "((#H1:1.0::0.1,b:1.0):1.0,c:1.0,(a:1.0)#H1:3.0::0.9);"
 @test writeTopology(deletehybridedge!(net0, net0.edge[5],false,true,false,false), round=true) ==
   "((#H2:1.0::0.2,((a:1.0)#H1:1.0::0.9)#H2:3.0::0.8):1.0,(#H1:1.0::0.1,b:1.0):1.0,c:1.0);"
 end # of testing deletehybridedge!
@@ -118,12 +118,10 @@ end
 net2  = readTopology(cui2str);
 @test_logs deleteleaf!(net2,"Xhellerii");
 @test_logs deleteleaf!(net2,"Xsignum");
-# earlier warning: """node 13 is a leaf. Will create a new node if needed, to set taxon "Xmayae" as outgroup."""
 @test_logs rootatnode!(net2,"Xmayae");
 net3  = readTopology(cui3str);
 @test_logs deleteleaf!(net3,"Xhellerii");
 @test_logs deleteleaf!(net3,"Xsignum");
-# earlier warning: """node 13 is a leaf. Will create a new node if needed, to set taxon "Xmayae" as outgroup."""
 @test hardwiredClusterDistance(net2, net3, true) == 3
 @test_logs rootatnode!(net3,"Xmayae");
 @test hardwiredClusterDistance(net2, net3, true) == 4

--- a/test/test_manipulateNet.jl
+++ b/test/test_manipulateNet.jl
@@ -237,6 +237,16 @@ PhyloNetworks.deleteaboveLSA!(net)
 @test isempty(net.hybrid)
 @test [n.name for n in net.nodes_changed] == ["H22","t1"]
 
+# deleteleaf! and removedegree2nodes! when the root starts a 2-cycle
+net = readTopology("((a,(((b)#H1,#H1))#H2),(#H2));")
+deleteleaf!(net, "a")
+@test writeTopology(net) == "((#H2),(((b)#H1,#H1))#H2);"
+removedegree2nodes!(net)
+@test writeTopology(net) == "((((b)#H1,#H1))#H2,#H2);"
+net = readTopology("((a,(((b)#H1,#H1))#H2),#H2);") # no degree-2 node adjacent to root this time
+deleteleaf!(net, "a", unroot=true)
+@test_broken writeTopology(net) == "((b)#H1,#H1);"
+
 end # of testset for other functions in manipulateNet
 
 end # of overall testset for this file

--- a/test/test_manipulateNet.jl
+++ b/test/test_manipulateNet.jl
@@ -36,6 +36,7 @@ node leaf  hybrid hasHybEdge name       inCycle edges'numbers
 9    false false  false      S3         -1      7    10   11  
 10   false false  true       S4         -1      3    11  
 """
+close(s);
 @test_throws ErrorException PhyloNetworks.getMinorParent(net.node[1])
 @test PhyloNetworks.getMajorParent(net.node[1]).number == 2
 @test PhyloNetworks.getMinorParent(net.node[3]).number == 6
@@ -71,8 +72,10 @@ net.node[1].name = "t7" # back to original name
 deleteleaf!(net, "t9", nofuse=true)
 @test writeTopology(net) == "((t7:0.23):0.15,(t6:0.17):0.21);"
 deleteleaf!(net, "t7")
-@test (@test_logs (:warn, r"Root") writeTopology(net)) == "t6;"
-deleteleaf!(net, "t6")
+@test writeTopology(net) == "(t6:0.17);"
+@test_logs (:warn, r"^Only 1 node") deleteleaf!(net, "t6")
+@test isempty(net.edge)
+@test isempty(net.node)
 end
 
 @testset "testing directEdges! and re-rootings" begin
@@ -245,7 +248,7 @@ removedegree2nodes!(net)
 @test writeTopology(net) == "((((b)#H1,#H1))#H2,#H2);"
 net = readTopology("((a,(((b)#H1,#H1))#H2),#H2);") # no degree-2 node adjacent to root this time
 deleteleaf!(net, "a", unroot=true)
-@test_broken writeTopology(net) == "((b)#H1,#H1);"
+@test writeTopology(net) == "(b)H1;"
 
 end # of testset for other functions in manipulateNet
 


### PR DESCRIPTION
in deleteleaf! and in removedegree2nodes! when an unrooted network is desired.

also, in deleteleaf!:
- more thorough removal of degree-2 nodes (bug fix)
- leave last external edge of only 1 leaf left (very minor breaking change)