### PR TITLE
read nexus tree blocks: with translate tables and networks

### DIFF
--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -82,7 +82,7 @@ readTopology
 readTopologyLevel1
 readInputTrees
 readMultiTopology
-readNexusTrees
+readnexus_treeblock
 readSnaqNetwork
 readTrees2CF
 countquartetsintrees

--- a/examples/test_reticulatetreeblock.nex
+++ b/examples/test_reticulatetreeblock.nex
@@ -1,0 +1,26 @@
+#NEXUS
+
+begin taxa;
+dimensions ntax=2;
+taxlabels
+A
+D
+;
+End;
+
+begin trees;
+
+translate
+5 tax5, [to check robustness]
+1 tax1,
+2 tax2,
+3 tax3,
+4 tax4
+;
+
+Tree	gt0=((4,(3,#7[&conv=7, relSize=0.08, affectedBlocks="{bark,dirty,dry}"]:0.001)[&height_95%_HPD={38.01,87.51}]:0.3):0.6,(2,(1:0.1)#7:0.9):10);
+tree gt1 = ((4,(3,#7[&conv=7,relSize=0.58, posterior=0.87]:0.001::0.57):0.3):0.6,(2,(1)#7));
+tree fake = this line won't match a newick string
+tree gt2 = (error will be caught and warning sent;
+
+end;

--- a/examples/test_reticulatetreeblock.nex
+++ b/examples/test_reticulatetreeblock.nex
@@ -18,9 +18,15 @@ translate
 4 tax4
 ;
 
-Tree	gt0=((4,(3,#7[&conv=7, relSize=0.08, affectedBlocks="{bark,dirty,dry}"]:0.001)[&height_95%_HPD={38.01,87.51}]:0.3):0.6,(2,(1:0.1)#7:0.9):10);
+Tree	bacter=((4,(3,#7[&conv=1, relSize=0.08, affectedBlocks="{bark,dirty,dry}"]:0.001)[&height_95%_HPD={38.01,87.51}]:0.3):0.6,(2,(1:0.1)#7:0.9):10);
 tree gt1 = ((4,(3,#7[&conv=7,relSize=0.58, posterior=0.87]:0.001::0.57):0.3):0.6,(2,(1)#7));
 tree fake = this line won't match a newick string
 tree gt2 = (error will be caught and warning sent;
+tree speciesnetwork = (((1:1.13,((2:0.21)#H1:0.89,(3:1.03,(#H1[&gamma=0.28]:0.30,4:0.51)S3:0.51)S4:0.08)S5:0.2):0.6,5:1.14):0.16);
 
 end;
+
+bacter example: https://raw.githubusercontent.com/taming-the-beast/Bacter-Tutorial/master/precooked_runs/bacter_tutorial.Ecoli_rplA.trees
+SpeciesNetwork examples:
+MCMC sample: https://raw.githubusercontent.com/mmatschiner/tutorials/master/bayesian_analysis_of_species_networks/res/speciesnetwork.trees
+summary: https://raw.githubusercontent.com/mmatschiner/tutorials/master/bayesian_analysis_of_species_networks/res/speciesnetwork_sum.trees

--- a/src/PhyloNetworks.jl
+++ b/src/PhyloNetworks.jl
@@ -66,7 +66,7 @@ module PhyloNetworks
         writeTableCF,
         mapAllelesCFtable,
         readInputTrees,
-        readNexusTrees,
+        readnexus_treeblock,
         summarizeDataCF,
         snaq!,
         readSnaqNetwork,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,6 +1,5 @@
-@deprecate phyloNetworklm phylolm
-@deprecate sigma2_estim sigma2_phylo
-@deprecate mu_estim mu_phylo
+@deprecate readNexusTrees readnexus_treeblock
+
 @deprecate getChild getchild false
 @deprecate getChildren getchildren false
 @deprecate getChildEdge getchildedge false

--- a/test/test_lm.jl
+++ b/test/test_lm.jl
@@ -387,9 +387,9 @@ phynetlm = phylolm(@formula(trait ~ pred), dfr, net; reml=false)
 @test bic(phynetlm) ≈ bic(fit_mat)
 
 # Deprecated methods
-@test phynetlm.model === phynetlm
-@test phynetlm.mf.f == formula(phynetlm)
-@test phynetlm.mm.m == modelmatrix(phynetlm)
+@test (@test_logs (:warn,r"^accessing") phynetlm.model) === phynetlm
+@test (@test_logs (:warn,r"^accessing") phynetlm.mf.f) == formula(phynetlm)
+@test (@test_logs (:warn,r"^accessing") phynetlm.mm.m) == modelmatrix(phynetlm)
 
 # unordered data
 dfr = dfr[[2,6,10,5,12,7,4,11,1,8,3,9], :]

--- a/test/test_readInputData.jl
+++ b/test/test_readInputData.jl
@@ -27,12 +27,13 @@
 
 
 @testset "test: reading nexus file" begin
-# example with translate table, reticulations, failed gamma in 2nd net, bad 3rd net
+# with translate table, hybrids, failed γ in net 2, bad net 3, v2 format in net 4
 nexusfile = joinpath(@__DIR__, "..", "examples", "test_reticulatetreeblock.nex")
 # nexusfile = joinpath(dirname(pathof(PhyloNetworks)), "..","examples","test_reticulatetreeblock.nex")
 vnet = (@test_logs (:warn, r"^hybrid edge") (:warn,r"^skipped") readnexus_treeblock(nexusfile));
-@test length(vnet) == 2
+@test length(vnet) == 3
 @test writeTopology(vnet[1]) == "((tax4,(tax3,#H7:0.001::0.08):0.3):0.6,(tax2,(tax1:0.1)#H7:0.9::0.92):10.0);"
+@test writeTopology(vnet[3]) == "((tax1:1.13,((tax2:0.21)#H1:0.89::0.72,(tax3:1.03,(#H1:0.3::0.28,tax4:0.51)S3:0.51)S4:0.08)S5:0.2):0.6,tax5:1.14);"
 # example without translate table and without reticulations
 nexusfile = joinpath(@__DIR__, "..", "examples", "test.nex")
 # nexusfile = joinpath(dirname(pathof(PhyloNetworks)), "..","examples","test.nex")

--- a/test/test_readInputData.jl
+++ b/test/test_readInputData.jl
@@ -27,13 +27,16 @@
 
 
 @testset "test: reading nexus file" begin
+# example with translate table, reticulations, failed gamma in 2nd net, bad 3rd net
+nexusfile = joinpath(@__DIR__, "..", "examples", "test_reticulatetreeblock.nex")
+# nexusfile = joinpath(dirname(pathof(PhyloNetworks)), "..","examples","test_reticulatetreeblock.nex")
+vnet = (@test_logs (:warn, r"^hybrid edge") (:warn,r"^skipped") readnexus_treeblock(nexusfile));
+@test length(vnet) == 2
+@test writeTopology(vnet[1]) == "((tax4,(tax3,#H7:0.001::0.08):0.3):0.6,(tax2,(tax1:0.1)#H7:0.9::0.92):10.0);"
+# example without translate table and without reticulations
 nexusfile = joinpath(@__DIR__, "..", "examples", "test.nex")
 # nexusfile = joinpath(dirname(pathof(PhyloNetworks)), "..","examples","test.nex")
-vnet = readNexusTrees(nexusfile);
-@test length(vnet) == 10
-@test length(vnet[10].edge) == 10
-@test vnet[10].edge[7].length ≈ 0.00035
-vnet = readNexusTrees(nexusfile, PhyloNetworks.readTopologyUpdate, false, false);
+vnet = readnexus_treeblock(nexusfile, PhyloNetworks.readTopologyUpdate, false, false; reticulate=false);
 @test length(vnet) == 10
 @test length(vnet[10].edge) == 9
 @test vnet[10].edge[7].length ≈ 0.00035


### PR DESCRIPTION
`readNexusTrees` changed to `readnexus_treeblock`
assumptions about network format: based on BEAST2 output.