### PR TITLE
Fix for the slow but constant increase in memory usage

### DIFF
--- a/src/snaq_optimization.jl
+++ b/src/snaq_optimization.jl
@@ -1241,7 +1241,9 @@ function optTopLevel!(currT::HybridNetwork, liktolAbs::Float64, Nfail::Integer, 
         writeTopologyLevel1(newT,true)
     end
     writelog && write(logfile, "\nBegins heuristic optimization of network------\n")
+    loopcount = 0
     while(absDiff > liktolAbs && failures < Nfail && currT.loglik > liktolAbs && stillmoves) #stops if close to zero because of new deviance form of the pseudolik
+        if (loopcount % 50) == 0 GC.gc() end
         if CHECKNET && !isempty(d.repSpecies)
             checkTop4multAllele(currT) || error("currT is not good for multiple alleles")
         end
@@ -1308,6 +1310,7 @@ function optTopLevel!(currT::HybridNetwork, liktolAbs::Float64, Nfail::Integer, 
             stillmoves = false
         end
         @debug "--------- loglik_$(count) end: earlier log can be discarded ----"
+        loopcount += 1
     end
     if ftolAbs > 1e-7 || ftolRel > 1e-7 || xtolAbs > 1e-7 || xtolRel > 1e-7
         writelog && write(logfile,"\nfound best network, now we re-optimize branch lengths and gamma more precisely")


### PR DESCRIPTION
The garbage collector does not get called by default in the snaq optimization loop, so memory slowly grows out of control for long optimizations.

Memory usage graph before this change:

![before](https://github.com/crsl4/PhyloNetworks.jl/assets/36932293/f3f62f9a-8a2f-4839-9cf3-92b0c7ef8224)

Memory usage graph after this change:

![after](https://github.com/crsl4/PhyloNetworks.jl/assets/36932293/60af4821-40de-4aaa-8deb-d20fb8ad0ba8)
